### PR TITLE
[선혜린 | 0731] Sse 연결 및 SseEmitter 설계 구조 구현

### DIFF
--- a/src/main/java/com/stylemycloset/sse/controller/SseController.java
+++ b/src/main/java/com/stylemycloset/sse/controller/SseController.java
@@ -1,0 +1,29 @@
+package com.stylemycloset.sse.controller;
+
+import com.stylemycloset.sse.service.SseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sse")
+public class SseController {
+
+  private final SseService sseService;
+
+  @GetMapping(path = "/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter connect(
+      // UserDetails 구현체 생성될 시 수정 필요 (UserDetails의 user 관련 정보로 대체)
+      @PathVariable Long userId,
+      @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId
+  ) {
+    String eventId = String.valueOf(System.currentTimeMillis());
+    return sseService.connect(userId, eventId, lastEventId);
+  }
+}

--- a/src/main/java/com/stylemycloset/sse/dto/SseInfo.java
+++ b/src/main/java/com/stylemycloset/sse/dto/SseInfo.java
@@ -1,0 +1,10 @@
+package com.stylemycloset.sse.dto;
+
+public record SseInfo(
+    long id,
+    String name,
+    Object data,
+    long createdAt
+) {
+
+}

--- a/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
+++ b/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
@@ -1,0 +1,34 @@
+package com.stylemycloset.sse.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class SseRepository {
+
+  private final ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>> userEmitters = new ConcurrentHashMap<>();
+
+  public void save(Long userId, SseEmitter emitter) {
+    userEmitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+  }
+
+  public void delete(Long userId, SseEmitter emitter) {
+    if(!userEmitters.containsKey(userId)) return;
+
+    List<SseEmitter> emitters = userEmitters.get(userId);
+    emitters.remove(emitter);
+    if(emitters.isEmpty()) userEmitters.remove(userId);
+  }
+
+  public Map<Long, CopyOnWriteArrayList<SseEmitter>> findAllEmitters() {
+    Map<Long, CopyOnWriteArrayList<SseEmitter>> map = new ConcurrentHashMap<>();
+    userEmitters.forEach((userId, emitters) ->
+      map.put(userId, new CopyOnWriteArrayList<>(emitters))
+    );
+    return map;
+  }
+}

--- a/src/main/java/com/stylemycloset/sse/service/SseService.java
+++ b/src/main/java/com/stylemycloset/sse/service/SseService.java
@@ -1,0 +1,8 @@
+package com.stylemycloset.sse.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SseService {
+
+  SseEmitter connect(Long userId, String eventId, String lastEventId);
+}

--- a/src/main/java/com/stylemycloset/sse/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/stylemycloset/sse/service/impl/SseServiceImpl.java
@@ -1,0 +1,87 @@
+package com.stylemycloset.sse.service.impl;
+
+import com.stylemycloset.sse.dto.SseInfo;
+import com.stylemycloset.sse.repository.SseRepository;
+import com.stylemycloset.sse.service.SseService;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SseServiceImpl implements SseService {
+
+  private final SseRepository sseRepository;
+
+  private final ConcurrentHashMap<Long, List<SseInfo>> userEvents = new ConcurrentHashMap<>();
+  private static final long DEFAULT_TIMEOUT = 30L * 60 * 1000;
+
+  public SseEmitter connect(Long userId, String eventId, String lastEventId) {
+
+    SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+    sseRepository.save(userId, emitter);
+
+    emitter.onCompletion(() -> sseRepository.delete(userId, emitter));
+    emitter.onTimeout(() -> sseRepository.delete(userId, emitter));
+    emitter.onError(e -> sseRepository.delete(userId, emitter));
+
+    sendToClient(userId, emitter, eventId, "connect", "Sse Connected");
+
+    if(lastEventId != null &&  !lastEventId.isEmpty()) {
+      long lastId = Long.parseLong(lastEventId);
+      List<SseInfo> missedInfo = userEvents.getOrDefault(userId, new CopyOnWriteArrayList<>()).stream()
+          .filter(event ->
+            event.id() > lastId
+          ).toList();
+
+      for(SseInfo info : missedInfo) {
+        sendToClient(userId, emitter, String.valueOf(info.id()), info.name(), info.data());
+      }
+    }
+
+    return emitter;
+  }
+
+  private void sendToClient(Long userId, SseEmitter emitter, String eventId, String eventName, Object data) {
+    try{
+      emitter.send(SseEmitter.event()
+          .id(eventId)
+          .name(eventName)
+          .data(data));
+      log.debug("[{}]의 {} SSE 이벤트 수신 완료 (eventId: {})", userId, eventName, eventId);
+    } catch (IOException e){
+      log.error("[{}]의 {} SSE 이벤트 실패 (eventId: {})", userId, eventName, eventId, e);
+      sseRepository.delete(userId, emitter);
+    }
+  }
+
+  @Scheduled(fixedRate = 2 * 60 * 1000)
+  private void cleanUpSseEmitter() {
+    sseRepository.findAllEmitters()
+        .forEach((userId, emitters) ->
+            emitters.forEach(emitter -> {
+              try{
+                emitter.send(SseEmitter.event().name("heartbeat").data("data"));
+              } catch (IOException e){
+                sseRepository.delete(userId, emitter);
+              }
+            }));
+  }
+
+  @Scheduled(fixedRate = 60 * 60 * 1000)
+  private void cleanUpSseInfos() {
+    long timeout = System.currentTimeMillis() - (60 * 60 * 1000);
+    userEvents.forEach((userId, events) -> {
+      events.removeIf(event -> event.createdAt() < timeout);
+      if(events.isEmpty()) userEvents.remove(userId);
+    });
+  }
+
+}

--- a/src/test/java/com/stylemycloset/sse/SseControllerTest.java
+++ b/src/test/java/com/stylemycloset/sse/SseControllerTest.java
@@ -1,0 +1,35 @@
+package com.stylemycloset.sse;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SseControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+
+  @WithMockUser(username = "testuser", roles = "USER")
+  @Test
+  public void sseConnect_returnSseEmitter() throws Exception {
+    // given
+    Long userId = 1L;
+
+    // when & then
+    mockMvc.perform(get("/api/sse/{userId}", userId)
+            .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+        .andExpect(status().isOk())
+        .andExpect(header().string("content-type", org.hamcrest.Matchers.containsString(MediaType.TEXT_EVENT_STREAM_VALUE)));
+  }
+}


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [x] 사용자별 SSE 연결 유지 및 재연결 처리 로직
- [x] Emitter/이벤트 메모리 관리용 스케쥴러 추가
- [x] SSE 컨트롤러 작성 (/api/sse)
- [x] SSE 컨트롤러 및 기본 통합 테스트 구현

### 변경 사항 상세

### 1. 무엇을 구현했는지

1. `SseServiceImpl`
- 사용자별 다중 SseEmitter 등록/삭제 로직 구현
- Sse 연결 시, SseEmitter를 생성하고 sseRepository에 저장
- 연결 종료/에러/타임아웃 발생 시 Emitter 자동 삭제
- Last-Event-ID가 존재할 경우, 미전송 이벤트(userEvents)만 필터링해 순차적으로 재전송
- 2분마다 heartbeat 이벤트를 모든 Emitter에 전송하여, 연결이 끊긴 Emitter를 정리
- 1시간마다 userEvents에서 오래된 이벤트(알림)를 주기적으로 삭제하여 메모리 사용 최적화

2. `SseRepository`
- 사용자별 SseEmitter 목록을 ConcurrentHashMap 기반으로 관리
- Emitter의 저장, 개별 삭제, 전체 조회 등 동시성 안전한 CRUD 기능 구현
   - Emitter가 모두 삭제된 경우 해당 userId의 맵 항목 자체도 삭제해 메모리 관리

3. `SseController`
- /api/sse/{userId} GET 엔드포인트 구현
- 클라이언트로부터 userId와 Last-Event-ID를 받아 SseServiceImpl의 connect 메서드 호출
   - userId는 추후 UserDetails에서 받아서 쓸 것으로 생각. 지금은 테스트 때문에 long타입으로 직접 받음.
- SseEmitter를 반환해 SSE 스트림 연결을 제공
+ controller단에서 SseEmitter를 만드는건 책임 위반이라 생각되어 SseController는 요청/응답만 하도록 하였습니다.

4. `SseInfo` 
- 알림 이벤트의 메타 정보를 담는 record 타입 도입
- 각 이벤트의 id, name, data, 생성 시각 정의

5. SseControllerTest
- SSE 엔드포인트 기본 연결 테스트 코드 작성
- userId로 요청 시 정상적으로 SseEmitter가 반환되고, content-type이 text/event-stream임을 검증 (결과는 아래에 첨부)

### 2. 왜 구현했는지

- 지속적인 실시간 알림을 제공하기 위해 SSE 기반의 시스템을 도입하였음.
- SseServiceImpl의 userEvents : 사용자가 짧은 시간에 다시 SseEmitter와 연결했을 때 SSE로 전송해주기 위해 SseInfo를 사용하여 저장.

### 3. 변경으로 인한 효과

- 사용자는 연결/재연결을 반복해도 알림 누락 없이 안정적으로 수신
- 연결이 장시간 유지될 때도 서버 메모리 사용량이 일정 수준으로 관리됨
- 컨트롤러 단에서 간결하게 SSE 연결 및 복구가 가능해 코드 유지보수성이 향상됨
- 테스트를 통해 기본 응답 포맷과 성공 여부를 쉽게 검증할 수 있음

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<img width="287" height="123" alt="테스트코드결과" src="https://github.com/user-attachments/assets/7b455415-5ac5-4628-9c39-10bccc637910" />

## 🎯 리뷰 포인트

- [ ]  사용자가 짧은 시간에 다시 SseEmitter와 연결했을 때 놓친 알림 메시지를 SSE로 전송해주기 위해 SseInfo를 사용하여 알림 데이터를 저장하는 userEvents를 만들었습니다. 
userEvents의 오래된 SseInfo를 정리하는 cleanUpSseInfos()를 만들긴 했는데 이렇게 알림 데이터를 저장하고 관리하는 방식이 효율적인 방식인지 판단이 안 섭니다. 혹시 비효율적이거나 아쉬운 점이 있다면 편하게 조언해주세요.

## 🔄 **기능 흐름**

1. 클라이언트가 `/api/sse/{userId}`로 연결 요청 (Last-Event-ID 헤더 포함될 수 있음.)
2. 서버는 사용자의 SseEmitter를 생성/등록, 연결 종료/에러 발생 시 자동 해제
3. 연결 시 "connect" 이벤트 전송, Last-Event-ID 존재 시 누락된 이벤트(알림 데이터 전송) 순차 전송
4. 2분마다 모든 Emitter에 heartbeat 이벤트 전송하여 유효성 검사
5. 1시간마다 과거 이벤트 메모리(userEvents) 정리
6. 클라이언트는 실시간 알림을 누락 없이 수신하며, 서버는 리소스를 안정적으로 관리

## 📚 관련 위키

- [트러블슈팅: OO 문제 해결]

## 💭 추가 고려사항

- UserDetails 구현체가 생성될 시 SseController에서 userId 매개변수는 지울 것. 

Closes #13 