### PR TITLE
[이준혁 | 0801] 오픈 api 데이터 가져오기

### DIFF
--- a/src/main/java/com/stylemycloset/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/stylemycloset/common/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.stylemycloset.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/stylemycloset/weather/service/WeatherBuilderHelper.java
+++ b/src/main/java/com/stylemycloset/weather/service/WeatherBuilderHelper.java
@@ -1,0 +1,116 @@
+package com.stylemycloset.weather.service;
+
+import com.stylemycloset.location.Location;
+import com.stylemycloset.weather.entity.Humidity;
+import com.stylemycloset.weather.entity.Precipitation;
+import com.stylemycloset.weather.entity.Temperature;
+import com.stylemycloset.weather.entity.Weather;
+import com.stylemycloset.weather.entity.WindSpeed;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class WeatherBuilderHelper {
+    private final LocalDateTime forecastedAt; // 예보 발표 시점
+    private final LocalDateTime forecastAt;   // 예보 적용 시점
+    private final Location location;
+
+    private Weather.SkyStatus skyStatus = Weather.SkyStatus.CLEAR;
+
+    // 임베디드 객체 초기값을 null 대신 명확히 초기화(기본값 또는 null 허용)
+    private Precipitation precipitation = new Precipitation(null, 0.0, 0.0);
+    private Temperature temperature = new Temperature(null, null, null, null);
+    private Humidity humidity = new Humidity(null, null);
+    private WindSpeed windSpeed = new WindSpeed(null, null);
+
+    private final Boolean isAlertTriggered = false;
+    private Weather.AlertType alertType = Weather.AlertType.NONE;
+
+    public WeatherBuilderHelper(String baseDate, String baseTime, String fcstDate, String fcstTime, Location location) {
+        this.forecastedAt = parseDateTime(baseDate, baseTime);
+        this.forecastAt = parseDateTime(fcstDate, fcstTime);
+        this.location = location;
+    }
+
+    private LocalDateTime parseDateTime(String dateStr, String timeStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+        return LocalDateTime.parse(dateStr + timeStr, formatter);
+    }
+
+    public void setCategoryValue(String category, String fcstValue) {
+        switch (category) {
+            case "PTY": // 강수 형태 (예: 비, 눈 등) - type
+                precipitation = new Precipitation(fcstValue, precipitation.getAmount(), precipitation.getProbability());
+                break;
+            case "PCP": // 강수량 - amount
+                precipitation = new Precipitation(precipitation.getType(), parseDoubleSafe(fcstValue), precipitation.getProbability());
+                break;
+            case "POP": // 강수확률 - probability
+                precipitation = new Precipitation(precipitation.getType(), precipitation.getAmount(), parseDoubleSafe(fcstValue));
+                break;
+            case "SNO": //적설량
+                precipitation = new Precipitation(precipitation.getType(), parseDoubleSafe(fcstValue), precipitation.getProbability());
+                break;
+            case "REH": // 습도 %
+                humidity = new Humidity(parseDoubleSafe(fcstValue), humidity.getComparedToDayBefore());
+                break;
+            case "TMP": // 기온 (현재)
+                temperature = new Temperature(parseDoubleSafe(fcstValue), temperature.getComparedToDayBefore(), temperature.getMin(), temperature.getMax());
+                break;
+            case "TMN": // 최저기온
+                temperature = new Temperature(temperature.getCurrent(), temperature.getComparedToDayBefore(), parseDoubleSafe(fcstValue), temperature.getMax());
+                break;
+            case "TMX": // 최고기온
+                temperature = new Temperature(temperature.getCurrent(), temperature.getComparedToDayBefore(), temperature.getMin(), parseDoubleSafe(fcstValue));
+                break;
+            case "UUU": // 풍속
+                windSpeed = new WindSpeed(parseDoubleSafe(fcstValue), windSpeed.getComparedToDayBefore());
+                break;
+            case "SKY": // 하늘 상태 (맑음, 흐림 등) - enum 매핑 필요
+                skyStatus = parseSkyStatus(fcstValue);
+                break;
+            default:
+                // 알 수 없는 카테고리 로깅
+                log.warn("알 수 없는 카테고리: {}", category);
+                break;
+        }
+    }
+
+    private double parseDoubleSafe(String value) {
+        try {
+            return Double.parseDouble(value);
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+
+    private Weather.SkyStatus parseSkyStatus(String value) {
+        switch (value) {
+            case "1":
+                return Weather.SkyStatus.CLEAR;
+            case "3":
+                return Weather.SkyStatus.MOSTLY_CLOUDY;
+            case "4":
+                return Weather.SkyStatus.CLOUDY;
+            default:
+                return Weather.SkyStatus.CLEAR;
+        }
+    }
+
+    public Weather build() {
+        return Weather.builder()
+            .forecastedAt(forecastedAt)
+            .forecastAt(forecastAt)
+            .location(location)
+            .skyStatus(skyStatus)
+            .precipitation(precipitation)
+            .temperature(temperature)
+            .humidity(humidity)
+            .windSpeed(windSpeed)
+            .isAlertTriggered(isAlertTriggered)
+            .alertType(alertType)
+            .build();
+    }
+}

--- a/src/main/java/com/stylemycloset/weather/service/openApiService.java
+++ b/src/main/java/com/stylemycloset/weather/service/openApiService.java
@@ -5,9 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.location.Location;
+import com.stylemycloset.weather.entity.Humidity;
+import com.stylemycloset.weather.entity.Precipitation;
+import com.stylemycloset.weather.entity.Temperature;
+import com.stylemycloset.weather.entity.Weather;
+import com.stylemycloset.weather.entity.WindSpeed;
 import com.stylemycloset.weather.repository.WeatherRepository;
 import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -34,35 +43,45 @@ public class openApiService {
     @Value("${external.market-index.num-of-rows:100}")
     private int numOfRows;
 
-    public void fetchData(String baseDate, String baseTime, Location location){
+    public void fetchData(String baseDate, String baseTime, Location location) {
         Set<String> seenKeys = new HashSet<>();
         int totalPages = (int) Math.ceil((double) 100 / numOfRows); // TODO: 총 개수 동적으로 바꾸기
+
+        List<JsonNode> allItems = new ArrayList<>();
 
         for (int page = 1; page <= totalPages; page++) {
             try {
                 String apiUrl = String.format("%s/getVilageFcst?serviceKey=%s&numOfRows=%d&pageNo=%d&"
                         + "base_date=%s&base_time=%s&nx=%d&ny=%d",
-                    baseUrl, serviceKey, page, numOfRows,baseDate,baseTime,location.getX(),location.getY());
+                    baseUrl, serviceKey, page, numOfRows, baseDate, baseTime, location.getX(), location.getY());
                 URI uri = new URI(apiUrl);
 
                 log.debug("[API 호출] 페이지 {}: {}", page, apiUrl);
 
                 String response = restTemplate.getForObject(uri, String.class);
 
-                JsonNode items = objectMapper.readTree(response)
+                JsonNode itemsNode = objectMapper.readTree(response)
                     .path("response").path("body").path("items").path("item");
 
-                if (items.isMissingNode() || items.isNull()) {
+                if (itemsNode.isMissingNode() || itemsNode.isNull()) {
                     log.warn("[경고] 페이지 {}에 데이터 없음", page);
                     continue;
                 }
 
-                if (items.isArray()) {
-                    for (JsonNode item : items) {
-                        processItem(item, seenKeys, baseDate);
+                if (itemsNode.isArray()) {
+                    for (JsonNode item : itemsNode) {
+                        String key = createUniqueKey(item);
+                        if (!seenKeys.add(key)) {
+                            log.debug("[중복 스킵] {}", key);
+                            continue;
+                        }
+                        allItems.add(item);
                     }
                 } else {
-                    processItem(items, seenKeys, baseDate);
+                    String key = createUniqueKey(itemsNode);
+                    if (seenKeys.add(key)) {
+                        allItems.add(itemsNode);
+                    }
                 }
 
                 log.info("[성공] 페이지 {} 처리 완료", page);
@@ -72,22 +91,53 @@ public class openApiService {
                 throw new StyleMyClosetException(ErrorCode.ERROR_CODE, Map.of("apiError", "api 호출 오류"));
             }
         }
+
+        // 중복 제거된 모든 items 를 한 번에 처리
+        processItems(allItems, baseDate, baseTime, location);
     }
 
-    private void processItem(JsonNode item, Set<String> seenKeys,String baseDate) throws Exception {
-        String indexClassification = item.path("idxCsf").asText();
-        String indexName = item.path("idxNm").asText();
-        String itemDate = item.path("basDt").asText();
-        String key = indexClassification + "|" + indexName;
+    private String createUniqueKey(JsonNode item) {
+        // 중복 체크용 키 생성: baseDate|baseTime|fcstDate|fcstTime|nx,ny|category
+        return item.path("baseDate").asText() + "|" +
+            item.path("baseTime").asText() + "|" +
+            item.path("fcstDate").asText() + "|" +
+            item.path("fcstTime").asText() + "|" +
+            item.path("nx").asText() + "," + item.path("ny").asText() + "|" +
+            item.path("category").asText();
+    }
 
-        if (!seenKeys.add(key)) {
-            log.debug("[중복 스킵] {}", key);
-            return;
+    private void processItems(List<JsonNode> items, String baseDate, String baseTime, Location location) {
+        // 키: fcstDate + fcstTime + nx + ny  (예보 시각+좌표) - 이걸 기준으로 하나의 Weather 객체 생성
+        Map<String, WeatherBuilderHelper> weatherBuilders = new HashMap<>();
+
+        for (JsonNode item : items) {
+            if (!item.path("baseDate").asText().equals(baseDate)) {
+                log.debug("[스킵] 기준일 불일치: {}", createUniqueKey(item));
+                continue;
+            }
+
+            String fcstDate = item.path("fcstDate").asText();
+            String fcstTime = item.path("fcstTime").asText();
+            String nx = item.path("nx").asText();
+            String ny = item.path("ny").asText();
+
+            String weatherKey = fcstDate + "|" + fcstTime + "|" + nx + "," + ny;
+
+            WeatherBuilderHelper builder = weatherBuilders.computeIfAbsent(weatherKey,
+                k -> new WeatherBuilderHelper(baseDate, baseTime, fcstDate, fcstTime, location));
+
+            String category = item.path("category").asText();
+            String fcstValue = item.path("fcstValue").asText();
+
+            // 카테고리별로 builder에 값 세팅
+            builder.setCategoryValue(category, fcstValue);
         }
 
-        if (!itemDate.equals(baseDate)) {
-            log.debug("[스킵] 기준일 불일치: {}", key);
-            return;
+        // 모든 builder 완성 후 Weather 객체 생성 및 저장 로직 추가 가능
+        for (WeatherBuilderHelper builder : weatherBuilders.values()) {
+            Weather weather = builder.build();
+            // 저장 또는 후처리
+            log.info("빌드된 Weather: {}", weather);
         }
     }
 }

--- a/src/main/java/com/stylemycloset/weather/service/openApiService.java
+++ b/src/main/java/com/stylemycloset/weather/service/openApiService.java
@@ -51,7 +51,7 @@ public class openApiService {
 
         for (int page = 1; page <= totalPages; page++) {
             try {
-                String apiUrl = String.format("%s/getVilageFcst?serviceKey=%s&numOfRows=%d&pageNo=%d&"
+                String apiUrl = String.format("%s/getVilageFcst?serviceKey=%s&dataType=JSON&numOfRows=%d&pageNo=%d&"
                         + "base_date=%s&base_time=%s&nx=%d&ny=%d",
                     baseUrl, serviceKey, page, numOfRows, baseDate, baseTime, location.getX(), location.getY());
                 URI uri = new URI(apiUrl);

--- a/src/main/java/com/stylemycloset/weather/service/openApiService.java
+++ b/src/main/java/com/stylemycloset/weather/service/openApiService.java
@@ -1,0 +1,93 @@
+package com.stylemycloset.weather.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stylemycloset.common.exception.ErrorCode;
+import com.stylemycloset.common.exception.StyleMyClosetException;
+import com.stylemycloset.location.Location;
+import com.stylemycloset.weather.repository.WeatherRepository;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class openApiService {
+    private final WeatherRepository weatherRepository;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${external.market-index.service-key}")
+    private String serviceKey;
+
+    @Value("${external.market-index.base-url}")
+    private String baseUrl;
+
+    @Value("${external.market-index.num-of-rows:100}")
+    private int numOfRows;
+
+    public void fetchData(String baseDate, String baseTime, Location location){
+        Set<String> seenKeys = new HashSet<>();
+        int totalPages = (int) Math.ceil((double) 100 / numOfRows); // TODO: 총 개수 동적으로 바꾸기
+
+        for (int page = 1; page <= totalPages; page++) {
+            try {
+                String apiUrl = String.format("%s/getVilageFcst?serviceKey=%s&numOfRows=%d&pageNo=%d&"
+                        + "base_date=%s&base_time=%s&nx=%d&ny=%d",
+                    baseUrl, serviceKey, page, numOfRows,baseDate,baseTime,location.getX(),location.getY());
+                URI uri = new URI(apiUrl);
+
+                log.debug("[API 호출] 페이지 {}: {}", page, apiUrl);
+
+                String response = restTemplate.getForObject(uri, String.class);
+
+                JsonNode items = objectMapper.readTree(response)
+                    .path("response").path("body").path("items").path("item");
+
+                if (items.isMissingNode() || items.isNull()) {
+                    log.warn("[경고] 페이지 {}에 데이터 없음", page);
+                    continue;
+                }
+
+                if (items.isArray()) {
+                    for (JsonNode item : items) {
+                        processItem(item, seenKeys, baseDate);
+                    }
+                } else {
+                    processItem(items, seenKeys, baseDate);
+                }
+
+                log.info("[성공] 페이지 {} 처리 완료", page);
+
+            } catch (Exception e) {
+                log.error("[실패] 페이지 {} 처리 중 예외 발생: {}", page, e.getMessage(), e);
+                throw new StyleMyClosetException(ErrorCode.ERROR_CODE, Map.of("apiError", "api 호출 오류"));
+            }
+        }
+    }
+
+    private void processItem(JsonNode item, Set<String> seenKeys,String baseDate) throws Exception {
+        String indexClassification = item.path("idxCsf").asText();
+        String indexName = item.path("idxNm").asText();
+        String itemDate = item.path("basDt").asText();
+        String key = indexClassification + "|" + indexName;
+
+        if (!seenKeys.add(key)) {
+            log.debug("[중복 스킵] {}", key);
+            return;
+        }
+
+        if (!itemDate.equals(baseDate)) {
+            log.debug("[스킵] 기준일 불일치: {}", key);
+            return;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,10 @@ management:
     web:
       exposure:
         include: health, metrics
+
+
+external:
+  market-index:
+    service-key: ${SERVICE_KEY}
+    base-url: https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0
+    num-of-rows: 100

--- a/src/test/java/com/stylemycloset/weather/service/OpenApiServiceTest.java
+++ b/src/test/java/com/stylemycloset/weather/service/OpenApiServiceTest.java
@@ -1,0 +1,191 @@
+package com.stylemycloset.weather.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stylemycloset.location.Location;
+import com.stylemycloset.weather.repository.WeatherRepository;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class OpenApiServiceTest {
+
+    @Mock
+    private WeatherRepository weatherRepository;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private openApiService openApiService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(openApiService, "serviceKey", System.getenv("SERVICE_KEY"));
+        ReflectionTestUtils.setField(openApiService, "baseUrl", "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0");
+        ReflectionTestUtils.setField(openApiService, "numOfRows", 100);
+    }
+
+    private final String mockResponseJson = """
+    {  
+        "response": {
+        "header": {
+          "resultCode": "00",
+          "resultMsg": "NORMAL_SERVICE"
+        },
+        "body": {
+          "dataType": "JSON",
+          "items": {
+            "item": [
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0300",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0400",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0500",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0600",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0700",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "LGT",
+                "fcstDate": "20250801",
+                "fcstTime": "0800",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "PTY",
+                "fcstDate": "20250801",
+                "fcstTime": "0300",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "PTY",
+                "fcstDate": "20250801",
+                "fcstTime": "0400",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "PTY",
+                "fcstDate": "20250801",
+                "fcstTime": "0500",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              },
+              {
+                "baseDate": "20250801",
+                "baseTime": "0230",
+                "category": "PTY",
+                "fcstDate": "20250801",
+                "fcstTime": "0600",
+                "fcstValue": "0",
+                "nx": 55,
+                "ny": 127
+              }
+            ]
+          },
+          "pageNo": 1,
+          "numOfRows": 10,
+          "totalCount": 60
+        }
+      }
+    }
+
+        """;
+
+    @Test
+    void fetchData_shouldProcessWeatherItemsSuccessfully() throws Exception {
+        // given
+        Location location = Location.builder()
+            .x(55).y(127)
+            .latitude(37.5665)
+            .longitude(126.9780)
+            .locationNames(List.of("서울", "중구"))
+            .build();
+
+        JsonNode jsonNode = new ObjectMapper().readTree(mockResponseJson)
+        .path("response").path("body").path("items").path("item");
+        when(restTemplate.getForObject(any(URI.class), eq(String.class)))
+            .thenReturn(mockResponseJson);
+
+        when(objectMapper.readTree(mockResponseJson)).thenReturn(jsonNode);
+
+        // when
+        openApiService.fetchData("20250801", "0200", location);
+
+        // then
+        // 여기에 저장 로직까지 넣는다면 save 호출 여부 확인 가능
+        // verify(weatherRepository).save(any(Weather.class));
+    }
+}
+

--- a/src/test/java/com/stylemycloset/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/stylemycloset/weather/service/WeatherServiceTest.java
@@ -10,6 +10,7 @@ import com.stylemycloset.weather.entity.Precipitation;
 import com.stylemycloset.weather.entity.Temperature;
 import com.stylemycloset.weather.entity.Weather;
 import com.stylemycloset.weather.entity.WindSpeed;
+import com.stylemycloset.weather.mapper.WeatherMapper;
 import com.stylemycloset.weather.repository.WeatherRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +24,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class WeatherServiceTest {
     @Mock
     private WeatherRepository weatherRepository;
+
+    @Mock
+    private WeatherMapper weatherMapper;
 
     @InjectMocks
     private WeatherServiceImpl weatherService;
@@ -59,8 +63,21 @@ public class WeatherServiceTest {
         when(weatherRepository.findByLocation(37.5665, 126.9780))
             .thenReturn(List.of(weather));
 
+        when(weatherMapper.toDto(weather)).thenReturn(new WeatherDto(
+            weather.getId(),
+            weather.getForecastedAt(),
+            weather.getForecastAt(),
+            weather.getLocation(),
+            weather.getSkyStatus(),
+            weather.getPrecipitation(),
+            weather.getHumidity(),
+            weather.getTemperature(),
+            weather.getWindSpeed()
+        ));
+
         // when
         List<WeatherDto> result = weatherService.getWeatherByCoordinates(37.5665, 126.9780);
+        //weatherService.getWeatherByCoordinates(37.5665, 126.9780);
 
         // then
         assertEquals(1, result.size());


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [ ] 기상청 openApi 데이터 가져오기

### 변경 사항 상세

### 1. 무엇을 변경했는지

생성
openApiService
WeatherBuilderHelper
openApiServiceTest

수정
application.yml

### 2. 왜 변경했는지

openApi 프로퍼티 등록을 위해 applicaion.yml 내용 추가하였습니다.
openApiService받을 기상청 데이터의 복잡성 때문에
weatherBuilderHelper 라는 클래스를 따로 두었습니다.

### 3. 변경으로 인한 효과
helper 를 따로 두어 객체 지향적인 설계 (SRP), 유지보수성 증가합니다.
기상청 json 데이터는 items안 여러 item있고, item 내용 중 category가 날씨 관련 데이터 종류(풍속, 기온, 습도 등)에 해당하는 데, 이 종류들이 다양하여 item를 분기처리할 필요가 있습니다. 이 기능을 openApiService에 몰아서 처리하면 코드전체가 복잡해지기에 helper 로 역할 분리하였습니다.

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<img width="1735" height="357" alt="스크린샷 2025-08-01 174234" src="https://github.com/user-attachments/assets/8ecd82cf-2351-4b3c-97a3-26974a916cc5" />


## 🎯 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐야 할 부분을 체크리스트로 작성해주세요 -->


- [ ]  에러 처리 로직 확인 필요

## 🔄 **기능 흐름**

1. 기준일자, 예보시간, 위치 지정
2. 위 3가지 값에 해당하는 기상청 데이터 jsonNode 로 불러옴
3. helper 에서 category에 따라 실측값 분기처리
4. weather에 값 넣고, weatherreposiotry에 저장

## 📚 관련 위키

<!-- 트러블슈팅 내용이 담긴 위키 링크를 첨부해주세요 -->


## 💭 추가 고려사항

<!-- 향후 개선이 필요한 부분이나 트레이드오프 사항을 작성해주세요 -->


Closes #22 