### PR TITLE
[허재석 | 0801] OOTD 피드 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
+++ b/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
@@ -2,14 +2,20 @@ package com.stylemycloset.ootd.controller;
 
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
+import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
 import com.stylemycloset.ootd.service.FeedService;
+import com.stylemycloset.weather.entity.Weather.SkyStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +32,18 @@ public class FeedController {
     FeedDto responseDto = feedService.createFeed(request);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+  }
+
+  @GetMapping
+  public ResponseEntity<FeedDtoCursorResponse> getFeeds(
+      @RequestParam(required = false) Long cursorId,
+      @PageableDefault(size = 10) Pageable pageable,
+      @RequestParam(required = false) String keywordLike,
+      @RequestParam(required = false) SkyStatus skyStatusEqual,
+      @RequestParam(required = false) Long authorIdEqual
+
+  ) {
+    FeedDtoCursorResponse response = feedService.getFeeds(cursorId, keywordLike, skyStatusEqual, authorIdEqual, pageable);
+    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/stylemycloset/ootd/dto/FeedDtoCursorResponse.java
+++ b/src/main/java/com/stylemycloset/ootd/dto/FeedDtoCursorResponse.java
@@ -1,0 +1,15 @@
+package com.stylemycloset.ootd.dto;
+
+import java.util.List;
+
+public record FeedDtoCursorResponse(
+    List<FeedDto> data,
+    String nextCursor,
+    String nextIdAfter,
+    boolean hasNext,
+    long totalCount,
+    String sortBy,
+    String sortDirection
+) {
+
+}

--- a/src/main/java/com/stylemycloset/ootd/entity/FeedClothes.java
+++ b/src/main/java/com/stylemycloset/ootd/entity/FeedClothes.java
@@ -44,7 +44,9 @@ public class FeedClothes extends CreatedAtEntity {
   }
 
   public static FeedClothes createFeedClothes(Feed feed, Cloth clothes) {
-    return new FeedClothes(feed, clothes);
+    FeedClothes feedClothes = new FeedClothes(feed, clothes);
+    feed.getFeedClothes().add(feedClothes);
+    return feedClothes;
   }
 
 }

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedRepository.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedRepository.java
@@ -3,6 +3,6 @@ package com.stylemycloset.ootd.repo;
 import com.stylemycloset.ootd.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FeedRepository extends JpaRepository<Feed, Long> {
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
 
 }

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryCustom.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.stylemycloset.ootd.repo;
 
-import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
+import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.weather.entity.Weather.SkyStatus;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface FeedRepositoryCustom {
-  FeedDtoCursorResponse findByConditions(Long cursorId, String keywordLike, SkyStatus skyStatus, Long authorId, Pageable pageable);
+
+  List<Feed> findByConditions(Long cursorId, String keywordLike, SkyStatus skyStatus, Long authorId,
+      Pageable pageable);
 }

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryCustom.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.stylemycloset.ootd.repo;
+
+import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
+import com.stylemycloset.weather.entity.Weather.SkyStatus;
+import org.springframework.data.domain.Pageable;
+
+public interface FeedRepositoryCustom {
+  FeedDtoCursorResponse findByConditions(Long cursorId, String keywordLike, SkyStatus skyStatus, Long authorId, Pageable pageable);
+}

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryImpl.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.stylemycloset.ootd.repo;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stylemycloset.ootd.entity.Feed;
+import com.stylemycloset.ootd.entity.QFeed;
+import com.stylemycloset.weather.entity.Weather.SkyStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Feed> findByConditions(Long cursorId, String keywordLike, SkyStatus skyStatus,
+      Long authorId, Pageable pageable) {
+    QFeed feed = QFeed.feed;
+
+    return queryFactory
+        .selectFrom(feed)
+        .join(feed.author).fetchJoin()
+        .leftJoin(feed.weather).fetchJoin()
+        .where(
+            ltCursorId(cursorId),
+            containsKeyword(keywordLike),
+            eqSkyStatus(skyStatus),
+            eqAuthorId(authorId)
+        )
+        .orderBy(feed.id.desc())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+  }
+
+  // 동적 쿼리를 위한 private 메서드
+  private BooleanExpression ltCursorId(Long cursorId) {
+    return cursorId != null ? QFeed.feed.id.lt(cursorId) : null;
+  }
+
+  private BooleanExpression containsKeyword(String keyword) {
+    return StringUtils.hasText(keyword) ? QFeed.feed.content.containsIgnoreCase(keyword) : null;
+  }
+
+  private BooleanExpression eqSkyStatus(SkyStatus skyStatus) {
+    return skyStatus != null ? QFeed.feed.weather.skyStatus.eq(skyStatus) : null;
+  }
+
+  private BooleanExpression eqAuthorId(Long authorId) {
+    return authorId != null ? QFeed.feed.author.id.eq(authorId) : null;
+  }
+}

--- a/src/main/java/com/stylemycloset/ootd/service/FeedService.java
+++ b/src/main/java/com/stylemycloset/ootd/service/FeedService.java
@@ -2,8 +2,14 @@ package com.stylemycloset.ootd.service;
 
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
+import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
+import com.stylemycloset.weather.entity.Weather.SkyStatus;
+import org.springframework.data.domain.Pageable;
 
 public interface FeedService {
 
   FeedDto createFeed(FeedCreateRequest request);
+
+  FeedDtoCursorResponse getFeeds(Long cursorId, String keywordLike, SkyStatus skyStatus,
+      Long authorId, Pageable pageable);
 }

--- a/src/main/java/com/stylemycloset/ootd/service/FeedServiceImpl.java
+++ b/src/main/java/com/stylemycloset/ootd/service/FeedServiceImpl.java
@@ -1,22 +1,22 @@
 package com.stylemycloset.ootd.service;
 
-import com.stylemycloset.ootd.dto.ClothesAttributeWithDefDto; // 나중에 import 변경 예정
+import com.stylemycloset.cloth.repository.ClothRepository;
+import com.stylemycloset.ootd.dto.AuthorDto;
 import com.stylemycloset.cloth.entity.Cloth;
-import com.stylemycloset.cloth.repository.ClothRepository; // 나중에 import 변경 예정
 import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
+import com.stylemycloset.ootd.dto.ClothesAttributeWithDefDto;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
-import com.stylemycloset.ootd.dto.OotdItemDto; // 나중에 import 변경 예정
+import com.stylemycloset.ootd.dto.OotdItemDto;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.entity.FeedClothes;
 import com.stylemycloset.ootd.repo.FeedClothesRepository;
 import com.stylemycloset.ootd.repo.FeedRepository;
-import com.stylemycloset.ootd.repo.UserRepository; // 나중에 import 변경 예정
-import com.stylemycloset.ootd.tempEnum.ClothesType; // 나중에 import 변경 예정
-import com.stylemycloset.ootd.dto.AuthorDto; // 나중에 import 변경 예정
+import com.stylemycloset.ootd.tempEnum.ClothesType;
 import com.stylemycloset.user.entity.User;
+import com.stylemycloset.user.repository.UserRepository;
 import com.stylemycloset.weather.dto.PrecipitationDto;
 import com.stylemycloset.weather.dto.TemperatureDto;
 import com.stylemycloset.weather.dto.WeatherSummaryDto;
@@ -58,11 +58,12 @@ public class FeedServiceImpl implements FeedService {
     }
 
     Feed newFeed = Feed.createFeed(author, weather, request.content());
-    feedRepository.save(newFeed);
 
     List<FeedClothes> feedClothesList = clothesList.stream()
         .map(cloth -> FeedClothes.createFeedClothes(newFeed, cloth))
         .collect(Collectors.toList());
+
+    feedRepository.save(newFeed);
     feedClothesRepository.saveAll(feedClothesList);
 
     return mapToFeedResponse(newFeed);
@@ -101,7 +102,7 @@ public class FeedServiceImpl implements FeedService {
 
   private FeedDto mapToFeedResponse(Feed feed) {
     List<Cloth> clothesList = feed.getFeedClothes().stream()
-        .map(feedClothes -> feedClothes.getClothes())
+        .map(FeedClothes::getClothes)
         .collect(Collectors.toList());
 
     AuthorDto authorDto = toAuthorDto(feed.getAuthor());

--- a/src/main/java/com/stylemycloset/ootd/tempEnum/SkyStatus.java
+++ b/src/main/java/com/stylemycloset/ootd/tempEnum/SkyStatus.java
@@ -1,5 +1,0 @@
-package com.stylemycloset.ootd.tempEnum;
-
-public enum SkyStatus {
-  CLEAR, MOSTLY_CLOUDY, CLOUDY
-}

--- a/src/main/java/com/stylemycloset/weather/dto/WeatherSummaryDto.java
+++ b/src/main/java/com/stylemycloset/weather/dto/WeatherSummaryDto.java
@@ -3,11 +3,12 @@ package com.stylemycloset.weather.dto;
 import com.stylemycloset.weather.entity.Precipitation;
 import com.stylemycloset.weather.entity.Temperature;
 import com.stylemycloset.weather.entity.Weather.SkyStatus;
-import java.util.UUID;
 
 public record WeatherSummaryDto(
-    UUID weatherId,
+    Long weatherId,
     SkyStatus skyStatus,
-    Precipitation precipitation,
-    Temperature temperature
-) {}
+    PrecipitationDto precipitation,
+    TemperatureDto temperature
+) {
+
+}

--- a/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
+++ b/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
@@ -1,32 +1,36 @@
 package com.stylemycloset.ootd.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.stylemycloset.cloth.entity.Cloth;
 import com.stylemycloset.cloth.entity.ClothingCategory;
 import com.stylemycloset.cloth.entity.ClothingCategoryType;
 import com.stylemycloset.cloth.repository.ClothRepository;
+import com.stylemycloset.common.dto.CursorResponse;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.repo.FeedClothesRepository;
 import com.stylemycloset.ootd.repo.FeedRepository;
-import com.stylemycloset.ootd.repo.UserRepository;
 import com.stylemycloset.user.entity.User;
+import com.stylemycloset.user.repository.UserRepository;
 import com.stylemycloset.weather.repository.WeatherRepository;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class FeedServiceImplTest {
@@ -36,54 +40,101 @@ class FeedServiceImplTest {
 
   @Mock
   private UserRepository userRepository;
-
   @Mock
   private ClothRepository clothRepository;
-
   @Mock
   private FeedRepository feedRepository;
-
   @Mock
   private FeedClothesRepository feedClothesRepository;
-
   @Mock
   private WeatherRepository weatherRepository;
 
-  @Test
-  @DisplayName("피드 생성 요청 시 FeedDto로 반환된다")
-  void createFeed_success() {
-    // 준비
-    Long authorId = 1L;
-    List<Long> clothesIds = List.of(101L, 102L);
-    FeedCreateRequest request = new FeedCreateRequest(authorId, null, clothesIds, "테스트 피드 내용");
+  @Nested
+  @DisplayName("피드 생성")
+  class CreateFeed {
 
-    // 가짜 모형
-    User mockUser = mock(User.class);
-    Cloth mockCloth1 = mock(Cloth.class);
-    Cloth mockCloth2 = mock(Cloth.class);
-    ClothingCategory mockCategory = mock(ClothingCategory.class);
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given (준비)
+      Long authorId = 1L;
+      List<Long> clothesIds = List.of(101L, 102L);
+      FeedCreateRequest request = new FeedCreateRequest(authorId, null, clothesIds, "테스트 피드 내용");
 
-    // 레포지토리 행동 정의
-    when(userRepository.findById(authorId)).thenReturn(Optional.of(mockUser));
-    when(clothRepository.findAllById(clothesIds)).thenReturn(List.of(mockCloth1, mockCloth2));
-    when(feedRepository.save(any(Feed.class))).thenAnswer(invocation -> {
-      Feed feed = invocation.getArgument(0);
-      ReflectionTestUtils.setField(feed, "id", 1L);
-      ReflectionTestUtils.setField(feed, "createdAt", Instant.now());
-      ReflectionTestUtils.setField(feed, "updatedAt", Instant.now());
-      return feed;
-    });
+      // Mock 객체 및 반환값 설정
+      User mockUser = mock(User.class);
+      Cloth mockCloth1 = mock(Cloth.class);
+      Cloth mockCloth2 = mock(Cloth.class);
+      ClothingCategory mockCategory = mock(ClothingCategory.class);
 
-    // MOCK 행동 정의
-    when(mockUser.getId()).thenReturn(authorId);
-    when(mockUser.getName()).thenReturn("테스트유저");
-    when(mockCloth1.getCategory()).thenReturn(mockCategory);
-    when(mockCloth2.getCategory()).thenReturn(mockCategory);
-    when(mockCategory.getName()).thenReturn(ClothingCategoryType.TOP);
+      when(userRepository.findById(authorId)).thenReturn(Optional.of(mockUser));
+      when(clothRepository.findAllById(clothesIds)).thenReturn(List.of(mockCloth1, mockCloth2));
+      when(feedRepository.save(any(Feed.class))).thenAnswer(invocation -> {
+        Feed feed = invocation.getArgument(0);
+        ReflectionTestUtils.setField(feed, "id", 1L);
+        ReflectionTestUtils.setField(feed, "createdAt", Instant.now());
+        ReflectionTestUtils.setField(feed, "updatedAt", Instant.now());
+        return feed;
+      });
 
-    FeedDto result = feedService.createFeed(request);
+      // Mock 객체의 상세 행동 정의
+      when(mockUser.getId()).thenReturn(authorId);
+      when(mockUser.getName()).thenReturn("테스트유저");
+      when(mockCloth1.getId()).thenReturn(101L);
+      when(mockCloth1.getName()).thenReturn("청바지");
+      when(mockCloth1.getCategory()).thenReturn(mockCategory);
+      when(mockCloth2.getId()).thenReturn(102L);
+      when(mockCloth2.getName()).thenReturn("흰티셔츠");
+      when(mockCloth2.getCategory()).thenReturn(mockCategory);
+      when(mockCategory.getName()).thenReturn(ClothingCategoryType.TOP);
 
-    // 검증
-    assertThat(result).isNotNull();
+      // when (실행)
+      FeedDto result = feedService.createFeed(request);
+
+      // then (검증)
+      assertThat(result).isNotNull();
+      assertThat(result.content()).isEqualTo("테스트 피드 내용");
+      assertThat(result.author().userId()).isEqualTo(authorId);
+      assertThat(result.ootds()).hasSize(2);
+      assertThat(result.ootds().get(0).name()).isEqualTo("청바지");
+
+      // verify (행위 검증)
+      verify(feedRepository, times(1)).save(any(Feed.class));
+      verify(feedClothesRepository, times(1)).saveAll(any());
+    }
+  }
+
+  // ✅ =============================================================
+  // ✅ 여기에 '피드 목록 조회' 단위 테스트가 새로 추가되었어요!
+  // ✅ =============================================================
+  @Nested
+  @DisplayName("피드 목록 조회")
+  class GetFeeds {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given (준비)
+      Long cursorId = null;
+      Pageable pageable = PageRequest.of(0, 10);
+
+      // Repository가 반환할 '가짜' 엔티티 목록 생성
+      Feed mockFeed = mock(Feed.class);
+      User mockUser = mock(User.class);
+      when(mockFeed.getAuthor()).thenReturn(mockUser); // ✅ Feed가 User를 반환하도록 설정
+      List<Feed> fakeFeeds = List.of(mockFeed);
+
+      // 🧠 "findByConditions 메서드가 호출되면, 우리가 만든 가짜 목록을 돌려줘!" 라고 설정
+      when(feedRepository.findByConditions(cursorId, null, null, null, pageable))
+          .thenReturn(fakeFeeds);
+
+      // when (실행)
+      CursorResponse<FeedDto> result = feedService.getFeeds(cursorId, null, null, null, pageable);
+
+      // then (검증)
+      assertThat(result).isNotNull();
+      assertThat(result.hasNext()).isFalse(); // 1개만 조회했으므로 다음 페이지 없음
+      assertThat(result.data()).hasSize(1);
+    }
   }
 }

--- a/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
+++ b/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
@@ -4,9 +4,9 @@ import com.stylemycloset.cloth.entity.Cloth;
 import com.stylemycloset.cloth.entity.ClothingCategory;
 import com.stylemycloset.cloth.entity.ClothingCategoryType;
 import com.stylemycloset.cloth.repository.ClothRepository;
-import com.stylemycloset.common.dto.CursorResponse;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
+import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.repo.FeedClothesRepository;
 import com.stylemycloset.ootd.repo.FeedRepository;
@@ -104,9 +104,6 @@ class FeedServiceImplTest {
     }
   }
 
-  // ✅ =============================================================
-  // ✅ 여기에 '피드 목록 조회' 단위 테스트가 새로 추가되었어요!
-  // ✅ =============================================================
   @Nested
   @DisplayName("피드 목록 조회")
   class GetFeeds {
@@ -121,15 +118,14 @@ class FeedServiceImplTest {
       // Repository가 반환할 '가짜' 엔티티 목록 생성
       Feed mockFeed = mock(Feed.class);
       User mockUser = mock(User.class);
-      when(mockFeed.getAuthor()).thenReturn(mockUser); // ✅ Feed가 User를 반환하도록 설정
+      when(mockFeed.getAuthor()).thenReturn(mockUser);
       List<Feed> fakeFeeds = List.of(mockFeed);
 
-      // 🧠 "findByConditions 메서드가 호출되면, 우리가 만든 가짜 목록을 돌려줘!" 라고 설정
       when(feedRepository.findByConditions(cursorId, null, null, null, pageable))
           .thenReturn(fakeFeeds);
 
       // when (실행)
-      CursorResponse<FeedDto> result = feedService.getFeeds(cursorId, null, null, null, pageable);
+      FeedDtoCursorResponse result = feedService.getFeeds(cursorId, null, null, null, pageable);
 
       // then (검증)
       assertThat(result).isNotNull();


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [x]  OOTD 피드 목록 조회 API (`GET /api/feeds`) 구현
- [x] QueryDSL을 이용한 동적 검색 조건 및 커서 기반 페이징 로직 구현
- [x] `Feed` 관련 Repository, Service, Controller 계층에 목록 조회 기능 추가
- [x] `FeedService` 단위 테스트 및 `FeedController` 통합 테스트 코드 추가

### 변경 사항 상세

### 1. 무엇을 변경했는지

- Repository: FeedRepositoryCustom 및 FeedRepositoryImpl을 생성하여, QueryDSL을 사용한 동적 조회 로직을 구현했습니다. cursorId, keywordLike, skyStatusEqual, authorIdEqual 파라미터를 처리할 수 있습니다.

- DTO: Swagger 명세서에 맞춰, 피드 목록 조회의 응답 형식인 FeedDtoCursorResponse를 ootd.dto 패키지 내에 생성했습니다.

- Service: FeedServiceImpl에 getFeeds 메서드를 추가했습니다. Controller로부터 받은 파라미터를 Repository에 전달하고, 조회된 엔티티 목록을 받아 페이징 처리 및 DTO 변환을 수행합니다.

- Controller: FeedController에 GET /api/feeds 엔드포인트를 추가했습니다. @RequestParam과 @PageableDefault를 사용하여 다양한 검색 조건과 페이징 정보를 받도록 구현했습니다.

- Test: FeedServiceImplTest에 목록 조회 로직에 대한 단위 테스트를, FeedControllerTest에 실제 API 호출을 시뮬레이션하는 통합 테스트를 추가하였습니다. 


### 2. 왜 변경했는지

- QueryDSL 을 도입하여 효율적인 커서 기반 페이네이션을 구현했습니다.

### 3. 변경으로 인한 효과

- QueryDSL 을 통해 향후 새로운 검색 조건이 추가되더라도, `FeedRepositoryImpl` 만 수정하면 되므로 유지보수 및 확장이 용이해졌습니다. 

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<!-- 테스트가 정상적으로 통과했는지 스크린샷을 첨부해주세요 -->

## 🎯 리뷰 포인트

- FeedRepositoryImpl.java : QueryDSL 을 사용한 동적 쿼리가 효율적이고 정확하게 작성되었는지 확인 부탁드립니다.

## 🔄 **기능 흐름**

클라이언트가 GET /api/feeds로 페이징 및 검색 파라미터 전송 →

FeedController가 @RequestParam으로 파라미터를 받아 FeedService.getFeeds() 호출 →

FeedService는 FeedRepository.findByConditions()를 호출하여 DB 조회 위임 →

FeedRepositoryImpl은 QueryDSL을 사용해 동적으로 SQL을 생성하고, DB에서 Feed 엔티티 목록 조회 →

FeedService는 조회된 엔티티 목록으로 페이징 정보를 계산하고, FeedDto 목록으로 변환 →

최종적으로 FeedDtoCursorResponse를 생성하여 Controller에 반환 →

Controller는 200 OK 상태 코드와 함께 FeedDtoCursorResponse를 응답

## 📚 관련 위키

## 💭 추가 고려사항

현재 FeedDtoCursorResponse 의 totalCount 는 0L로 하드코딩 되어있습니다. 전체 피드 개수가 꼭 필요한 경우 별도 COUNT 쿼리를 실행하는 로직을 추가해야 합니다. 


Closes #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 피드 목록을 커서 기반 페이지네이션과 다양한 필터(키워드, 날씨, 작성자)로 조회할 수 있는 GET API(/api/feeds)가 추가되었습니다.

* **버그 수정**
  * 피드 생성 시 피드와 옷의 연관관계 저장 방식이 개선되었습니다.

* **테스트**
  * 피드 목록 조회와 페이지네이션, 필터링 기능에 대한 컨트롤러 및 서비스 단위 테스트가 추가되었습니다.

* **리팩터**
  * DTO 및 서비스 내부 변환 로직이 개선되어 코드 가독성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->