### PR TITLE
[허재석 | 0811] 피드 댓글 조회

### DIFF
--- a/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
+++ b/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
@@ -90,16 +90,6 @@ public class FeedController {
     return ResponseEntity.ok(response);
   }
 
-  @DeleteMapping("/{feedId}")
-  public ResponseEntity<Void> deleteFeed(@PathVariable Long feedId, Authentication authentication) {
-    User user = userRepository.findByEmail(authentication.getName())
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
-
-    feedService.deleteFeed(user.getId(), feedId);
-
-    return ResponseEntity.noContent().build();
-  }
-
   @PatchMapping("/{feedId}")
   public ResponseEntity<FeedDto> updateFeed(@PathVariable Long feedId,
       @Valid @RequestBody FeedUpdateRequest request, Authentication authentication) {

--- a/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
+++ b/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
@@ -1,5 +1,7 @@
 package com.stylemycloset.ootd.controller;
 
+import com.stylemycloset.ootd.dto.CommentCursorResponse;
+import com.stylemycloset.ootd.dto.CommentSearchRequest;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
@@ -77,6 +79,15 @@ public class FeedController {
     feedService.deleteFeed(user.getId(), feedId);
 
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/{feedId}/comments")
+  public ResponseEntity<CommentCursorResponse> getComments(
+      @PathVariable Long feedId,
+      @Valid CommentSearchRequest request
+  ) {
+    CommentCursorResponse response = feedService.getComments(feedId, request);
+    return ResponseEntity.ok(response);
   }
 
   @DeleteMapping("/{feedId}")

--- a/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
+++ b/src/main/java/com/stylemycloset/ootd/controller/FeedController.java
@@ -79,6 +79,16 @@ public class FeedController {
     return ResponseEntity.noContent().build();
   }
 
+  @DeleteMapping("/{feedId}")
+  public ResponseEntity<Void> deleteFeed(@PathVariable Long feedId, Authentication authentication) {
+    User user = userRepository.findByEmail(authentication.getName())
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+    feedService.deleteFeed(user.getId(), feedId);
+
+    return ResponseEntity.noContent().build();
+  }
+
   @PatchMapping("/{feedId}")
   public ResponseEntity<FeedDto> updateFeed(@PathVariable Long feedId,
       @Valid @RequestBody FeedUpdateRequest request, Authentication authentication) {

--- a/src/main/java/com/stylemycloset/ootd/dto/CommentCursorResponse.java
+++ b/src/main/java/com/stylemycloset/ootd/dto/CommentCursorResponse.java
@@ -1,0 +1,15 @@
+package com.stylemycloset.ootd.dto;
+
+import java.util.List;
+
+public record CommentCursorResponse(
+    List<CommentDto> data,
+    String nextCursor,
+    Long nextIdAfter,
+    boolean hasNext,
+    long totalCount,
+    String sortBy,
+    String sortDirection
+) {
+
+}

--- a/src/main/java/com/stylemycloset/ootd/dto/CommentSearchRequest.java
+++ b/src/main/java/com/stylemycloset/ootd/dto/CommentSearchRequest.java
@@ -1,0 +1,12 @@
+package com.stylemycloset.ootd.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CommentSearchRequest(
+    String cursor,
+    Long idAfter,
+    @NotNull(message = "limit 값은 필수입니다.")
+    Integer limit
+) {
+
+}

--- a/src/main/java/com/stylemycloset/ootd/entity/FeedComment.java
+++ b/src/main/java/com/stylemycloset/ootd/entity/FeedComment.java
@@ -2,7 +2,16 @@ package com.stylemycloset.ootd.entity;
 
 import com.stylemycloset.common.entity.SoftDeletableEntity;
 import com.stylemycloset.user.entity.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -16,20 +25,26 @@ import org.hibernate.annotations.Where;
 @Where(clause = "deleted_at IS NULL")
 public class FeedComment extends SoftDeletableEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "feed_comments_seq_gen")
-    @SequenceGenerator(name = "feed_comments_seq_gen", sequenceName = "feed_comments_id_seq", allocationSize = 1)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "feed_comments_seq_gen")
+  @SequenceGenerator(name = "feed_comments_seq_gen", sequenceName = "feed_comments_id_seq", allocationSize = 1)
+  private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "feed_id", nullable = false)
-    private Feed feed;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "feed_id", nullable = false)
+  private Feed feed;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    private User author;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "author_id", nullable = false)
+  private User author;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;
+  @Column(columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  public FeedComment(Feed feed, User author, String content) {
+    this.feed = feed;
+    this.author = author;
+    this.content = content;
+  }
 
 }

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepository.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepository.java
@@ -1,0 +1,10 @@
+package com.stylemycloset.ootd.repo;
+
+import com.stylemycloset.ootd.entity.Feed;
+import com.stylemycloset.ootd.entity.FeedComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedCommentRepository extends JpaRepository<FeedComment, Long>, FeedCommentRepositoryCustom {
+
+  Long feed(Feed feed);
+}

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepositoryCustom.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.stylemycloset.ootd.repo;
+
+import com.stylemycloset.ootd.dto.CommentSearchRequest;
+import com.stylemycloset.ootd.entity.FeedComment;
+import java.util.List;
+
+public interface FeedCommentRepositoryCustom {
+
+  List<FeedComment> findByFeedIdWithCursor(Long feedId, CommentSearchRequest request);
+
+}

--- a/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepositoryImpl.java
+++ b/src/main/java/com/stylemycloset/ootd/repo/FeedCommentRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.stylemycloset.ootd.repo;
+
+import static com.stylemycloset.ootd.entity.QFeedComment.feedComment;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stylemycloset.ootd.dto.CommentSearchRequest;
+import com.stylemycloset.ootd.entity.FeedComment;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedCommentRepositoryImpl implements FeedCommentRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<FeedComment> findByFeedIdWithCursor(Long feedId, CommentSearchRequest request) {
+    int limit = request.limit() != null ? request.limit() : 10;
+
+    return queryFactory
+        .selectFrom(feedComment)
+        .join(feedComment.author).fetchJoin()
+        .where(
+            feedComment.feed.id.eq(feedId),
+            cursorCondition(request)       // 커서 조건
+        )
+        .orderBy(feedComment.createdAt.desc(), feedComment.id.desc()) // 최신순 정렬
+        .limit(limit + 1)
+        .fetch();
+  }
+
+  private BooleanExpression cursorCondition(CommentSearchRequest request) {
+    if (request.cursor() == null || request.idAfter() == null) {
+      return null; // 첫 페이지
+    }
+
+    Instant cursorDate = Instant.parse(request.cursor());
+    return feedComment.createdAt.lt(cursorDate)
+        .or(feedComment.createdAt.eq(cursorDate).and(feedComment.id.lt(request.idAfter())));
+  }
+}

--- a/src/main/java/com/stylemycloset/ootd/service/FeedService.java
+++ b/src/main/java/com/stylemycloset/ootd/service/FeedService.java
@@ -1,5 +1,7 @@
 package com.stylemycloset.ootd.service;
 
+import com.stylemycloset.ootd.dto.CommentCursorResponse;
+import com.stylemycloset.ootd.dto.CommentSearchRequest;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
@@ -19,4 +21,6 @@ public interface FeedService {
   FeedDto updateFeed(Long userId, Long feedId, FeedUpdateRequest request);
 
   void deleteFeed(Long userId, Long feedId);
+
+  CommentCursorResponse getComments(Long feedId, CommentSearchRequest request);
 }

--- a/src/main/java/com/stylemycloset/ootd/service/FeedServiceImpl.java
+++ b/src/main/java/com/stylemycloset/ootd/service/FeedServiceImpl.java
@@ -10,6 +10,9 @@ import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.ootd.dto.AuthorDto;
 import com.stylemycloset.ootd.dto.ClothesAttributeWithDefDto;
+import com.stylemycloset.ootd.dto.CommentCursorResponse;
+import com.stylemycloset.ootd.dto.CommentDto;
+import com.stylemycloset.ootd.dto.CommentSearchRequest;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.weather.dto.*;
@@ -19,8 +22,10 @@ import com.stylemycloset.ootd.dto.FeedUpdateRequest;
 import com.stylemycloset.ootd.dto.OotdItemDto;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.entity.FeedClothes;
+import com.stylemycloset.ootd.entity.FeedComment;
 import com.stylemycloset.ootd.entity.FeedLike;
 import com.stylemycloset.ootd.repo.FeedClothesRepository;
+import com.stylemycloset.ootd.repo.FeedCommentRepository;
 import com.stylemycloset.ootd.repo.FeedLikeRepository;
 import com.stylemycloset.ootd.repo.FeedRepository;
 import com.stylemycloset.ootd.tempEnum.ClothesType;
@@ -50,6 +55,7 @@ public class FeedServiceImpl implements FeedService {
   private final ClothRepository clothRepository;
   private final WeatherRepository weatherRepository;
   private final FeedLikeRepository feedLikeRepository;
+  private final FeedCommentRepository feedCommentRepository;
 
   @Override
   @Transactional
@@ -259,5 +265,46 @@ public class FeedServiceImpl implements FeedService {
     }
 
     feedRepository.delete(feed);
+  }
+
+  @Override
+  public CommentCursorResponse getComments(Long feedId, CommentSearchRequest request) {
+    if (!feedRepository.existsById(feedId)) {
+      throw new StyleMyClosetException(ErrorCode.FEED_NOT_FOUND, Map.of("feedId", feedId));
+    }
+
+    List<FeedComment> comments = feedCommentRepository.findByFeedIdWithCursor(feedId, request);
+
+    int limit = request.limit();
+    boolean hasNext = comments.size() > limit;
+    if (hasNext) {
+      comments.remove(limit);
+    }
+
+    String nextCursor = null;
+    Long nextIdAfter = null;
+    if (hasNext && !comments.isEmpty()) {
+      FeedComment lastComment = comments.get(comments.size() - 1);
+      nextCursor = lastComment.getCreatedAt().toString();
+      nextIdAfter = lastComment.getId();
+    }
+
+    List<CommentDto> commentDtos = comments.stream()
+        .map(this::toCommentDto) // DTO 변환
+        .collect(Collectors.toList());
+
+    // TODO: totalCount 로직 추가 필요
+    return new CommentCursorResponse(commentDtos, nextCursor, nextIdAfter, hasNext, 0L, "createdAt",
+        "DESC");
+  }
+
+  private CommentDto toCommentDto(FeedComment comment) {
+    return new CommentDto(
+        comment.getId(),
+        comment.getCreatedAt(),
+        comment.getFeed().getId(),
+        toAuthorDto(comment.getAuthor()),
+        comment.getContent()
+    );
   }
 }


### PR DESCRIPTION
## 빠르게 구현 후 추후에 작성할 예정입니다 
### 로컬 통합 브랜치 전략으로 진행하고 있습니다.
###  다른 기능 리뷰는 중복되니 피드 댓글 조회만 리뷰해주시면 될 것 같습니다. 
--
## 📋 작업 내용

### 구현 사항

- [ ]  기능 A 구현
- [ ]  기능 B 수정
- [ ]  버그 C 해결

### 변경 사항 상세

### 1. 무엇을 변경했는지

<!-- 변경한 내용을 구체적으로 작성해주세요 -->

### 2. 왜 변경했는지

<!-- 변경 이유와 배경을 설명해주세요 -->

### 3. 변경으로 인한 효과

<!-- 성능 개선, 사용성 향상 등 변경의 효과를 작성해주세요 -->

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<!-- 테스트가 정상적으로 통과했는지 스크린샷을 첨부해주세요 -->

## 🎯 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐야 할 부분을 체크리스트로 작성해주세요 -->

- [ ]  컴포넌트 구조가 적절한지 확인 필요
- [ ]  성능 최적화 로직 검토 필요
- [ ]  에러 처리 로직 확인 필요

## 🔄 **기능 흐름**

1. 사용자가 URL 입력 →
2. `UrlParserService`에서 URL 분석 및 정보 추출 →
3. 추출한 데이터를 기반으로 `Cloth` 생성 →
4. DB에 저장 및 응답 반환

## 📚 관련 위키

<!-- 트러블슈팅 내용이 담긴 위키 링크를 첨부해주세요 -->

- [트러블슈팅: OO 문제 해결](https://www.notion.so/%EC%9C%84%ED%82%A4%EB%A7%81%ED%81%AC1)
- [트러블슈팅: XX 성능 개선](https://www.notion.so/%EC%9C%84%ED%82%A4%EB%A7%81%ED%81%AC2)

## 💭 추가 고려사항

<!-- 향후 개선이 필요한 부분이나 트레이드오프 사항을 작성해주세요 -->


Closes #64 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 피드 댓글 조회 기능 추가: 커서 기반 페이지네이션으로 최신순 댓글을 불러오고 다음 페이지 여부/커서를 제공합니다. limit 파라미터로 개수 지정 가능하며 비로그인 사용자도 이용할 수 있습니다.
  - 잘못된 피드 ID로 요청 시 404 상태 코드로 응답해 오류 상황을 명확히 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->