### PR TITLE
[선혜린 | 0813] 의상 제외 나머지 이벤트 발행 연결 (Test 포함)

### DIFF
--- a/src/main/java/com/stylemycloset/directmessage/service/impl/DirectMessageServiceImpl.java
+++ b/src/main/java/com/stylemycloset/directmessage/service/impl/DirectMessageServiceImpl.java
@@ -9,10 +9,12 @@ import com.stylemycloset.directmessage.exception.DirectMessageSelfForbiddenExcep
 import com.stylemycloset.directmessage.mapper.DirectMessageMapper;
 import com.stylemycloset.directmessage.repository.DirectMessageRepository;
 import com.stylemycloset.directmessage.service.DirectMessageService;
+import com.stylemycloset.notification.event.domain.DMSentEvent;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.exception.UserNotFoundException;
 import com.stylemycloset.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class DirectMessageServiceImpl implements DirectMessageService {
   private final DirectMessageRepository directMessageRepository;
   private final UserRepository userRepository;
   private final DirectMessageMapper directMessageMapper;
+  private final ApplicationEventPublisher publisher;
 
   @Transactional
   @Override
@@ -35,6 +38,8 @@ public class DirectMessageServiceImpl implements DirectMessageService {
     DirectMessage directMessage = directMessageRepository.save(new DirectMessage(
         sender, receiver, request.content()
     ));
+
+    publisher.publishEvent(new DMSentEvent(directMessage.getId(), sender.getName()));
 
     return directMessageMapper.toResult(directMessage);
   }

--- a/src/main/java/com/stylemycloset/follow/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/stylemycloset/follow/service/impl/FollowServiceImpl.java
@@ -14,9 +14,11 @@ import com.stylemycloset.follow.exception.FollowSelfForbiddenException;
 import com.stylemycloset.follow.mapper.FollowMapper;
 import com.stylemycloset.follow.repository.FollowRepository;
 import com.stylemycloset.follow.service.FollowService;
+import com.stylemycloset.notification.event.domain.FollowEvent;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,7 @@ public class FollowServiceImpl implements FollowService {
   private final FollowRepository followRepository;
   private final UserRepository userRepository;
   private final FollowMapper followMapper;
+  private final ApplicationEventPublisher publisher;
 
   @Transactional
   @Override
@@ -45,6 +48,8 @@ public class FollowServiceImpl implements FollowService {
       return deletedFollow;
     }).orElseGet(() -> new Follow(followee, follower));
     Follow savedFollow = followRepository.save(follow);
+
+    publisher.publishEvent(new FollowEvent(followee.getId(), follower.getName()));
 
     return followMapper.toResult(savedFollow);
   }

--- a/src/main/java/com/stylemycloset/weather/controller/WeatherController.java
+++ b/src/main/java/com/stylemycloset/weather/controller/WeatherController.java
@@ -1,12 +1,13 @@
 package com.stylemycloset.weather.controller;
 
+import com.stylemycloset.security.ClosetUserDetails;
 import com.stylemycloset.weather.dto.WeatherAPILocation;
 import com.stylemycloset.weather.dto.WeatherDto;
 import com.stylemycloset.weather.service.WeatherService;
-import com.stylemycloset.weather.service.WeatherServiceImpl;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,9 +23,10 @@ public class WeatherController {
     @GetMapping
     public ResponseEntity<List<WeatherDto>> getWeathers(
         @RequestParam double latitude,
-        @RequestParam double longitude
+        @RequestParam double longitude,
+        @AuthenticationPrincipal ClosetUserDetails principal
     ) {
-        weatherService.checkWeather(latitude, longitude);
+        weatherService.checkWeather(latitude, longitude, principal.getUserId());
         List<WeatherDto> weathers = weatherService.getWeatherByCoordinates(latitude, longitude);
         return ResponseEntity.ok(weathers);
     }

--- a/src/main/java/com/stylemycloset/weather/dto/WeatherAlertEvent.java
+++ b/src/main/java/com/stylemycloset/weather/dto/WeatherAlertEvent.java
@@ -1,5 +1,0 @@
-package com.stylemycloset.weather.dto;
-
-public record WeatherAlertEvent(Long receiverId,
-                                Long weatherId,
-                                String message) {}

--- a/src/main/java/com/stylemycloset/weather/service/WeatherService.java
+++ b/src/main/java/com/stylemycloset/weather/service/WeatherService.java
@@ -2,11 +2,10 @@ package com.stylemycloset.weather.service;
 
 import com.stylemycloset.weather.dto.WeatherAPILocation;
 import com.stylemycloset.weather.dto.WeatherDto;
-import com.stylemycloset.weather.entity.Weather;
 import java.util.List;
 
 public interface WeatherService {
     public List<WeatherDto> getWeatherByCoordinates(double latitude, double longitude);
     public WeatherAPILocation getLocation(Double latitude, Double longitude);
-    public void checkWeather(Double latitude, Double longitude);
+    public void checkWeather(Double latitude, Double longitude, Long userId);
 }

--- a/src/main/java/com/stylemycloset/weather/service/WeatherServiceImpl.java
+++ b/src/main/java/com/stylemycloset/weather/service/WeatherServiceImpl.java
@@ -4,8 +4,8 @@ import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.location.Location;
 import com.stylemycloset.location.LocationRepository;
+import com.stylemycloset.notification.event.domain.WeatherAlertEvent;
 import com.stylemycloset.weather.dto.WeatherAPILocation;
-import com.stylemycloset.weather.dto.WeatherAlertEvent;
 import com.stylemycloset.weather.dto.WeatherDto;
 import com.stylemycloset.weather.entity.Weather;
 import com.stylemycloset.weather.entity.Weather.AlertType;
@@ -20,8 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-
 import org.springframework.stereotype.Service;
 
 @Service
@@ -48,7 +46,7 @@ public class WeatherServiceImpl implements WeatherService {
         return locationMapper.toDto(location);
     }
 
-    public void checkWeather(Double latitude, Double longitude) {
+    public void checkWeather(Double latitude, Double longitude, Long userId) {
 
         Optional<Weather> weather=  getTodayWeatherByLocation(latitude, longitude);
         Weather data = weather.orElseThrow(
@@ -75,7 +73,7 @@ public class WeatherServiceImpl implements WeatherService {
             }
 
             String message = messageBuilder.toString().trim();
-            //eventPublisher.publishEvent(new WeatherAlertEvent(data.getId(), message));
+            eventPublisher.publishEvent(new WeatherAlertEvent(userId, data.getId(), message));
         }
     }
 

--- a/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
+++ b/src/test/java/com/stylemycloset/ootd/service/FeedServiceImplTest.java
@@ -14,6 +14,7 @@ import com.stylemycloset.cloth.entity.ClothingCategoryType;
 import com.stylemycloset.cloth.repository.ClothRepository;
 import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
+import com.stylemycloset.notification.event.domain.FeedLikedEvent;
 import com.stylemycloset.ootd.dto.FeedCreateRequest;
 import com.stylemycloset.ootd.dto.FeedDto;
 import com.stylemycloset.ootd.dto.FeedDtoCursorResponse;
@@ -42,6 +43,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,6 +65,8 @@ class FeedServiceImplTest {
   private WeatherRepository weatherRepository;
   @Mock
   private FeedLikeRepository feedLikeRepository;
+  @Mock
+  private ApplicationEventPublisher publisher;
 
   @Nested
   @DisplayName("피드 생성")
@@ -199,13 +203,15 @@ class FeedServiceImplTest {
     when(feedRepository.findById(feedId)).thenReturn(Optional.of(mockFeed));
     when(feedLikeRepository.findByUserAndFeed(mockUser, mockFeed)).thenReturn(Optional.empty());
     when(mockFeed.getAuthor()).thenReturn(mock(User.class));
-
+    when(mockFeed.getId()).thenReturn(feedId);
+    when(mockUser.getId()).thenReturn(userId);
     // when
     feedService.toggleLike(userId, feedId);
 
     // then
     verify(feedLikeRepository, times(1)).save(any(FeedLike.class));
     verify(feedLikeRepository, times(0)).delete(any());
+    verify(publisher).publishEvent(any(FeedLikedEvent.class));
   }
 
   @Test

--- a/src/test/java/com/stylemycloset/user/controller/UserControllerTest.java
+++ b/src/test/java/com/stylemycloset/user/controller/UserControllerTest.java
@@ -1,14 +1,22 @@
 package com.stylemycloset.user.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stylemycloset.IntegrationTestSupport;
+import com.stylemycloset.notification.dto.NotificationDto;
+import com.stylemycloset.sse.service.SseService;
 import com.stylemycloset.user.dto.request.ChangePasswordRequest;
 import com.stylemycloset.user.dto.request.ProfileUpdateRequest;
 import com.stylemycloset.user.dto.request.UserCreateRequest;
@@ -29,6 +37,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +55,9 @@ public class UserControllerTest extends IntegrationTestSupport {
 
   @Autowired
   private UserRepository userRepository;
+
+  @MockitoBean
+  private SseService sseService;
 
   private UserCreateRequest userRequest1 = new UserCreateRequest("tester1", "tester1@naver.com",
       "testtest123!");
@@ -116,6 +129,13 @@ public class UserControllerTest extends IntegrationTestSupport {
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.role").value("ADMIN"));
+
+    if (TestTransaction.isActive()) {
+      TestTransaction.flagForCommit();
+      TestTransaction.end();
+    }
+
+    verify(sseService).sendNotification(any(NotificationDto.class));
   }
 
   @Test

--- a/src/test/java/com/stylemycloset/weather/service/WeatherServiceTest.java
+++ b/src/test/java/com/stylemycloset/weather/service/WeatherServiceTest.java
@@ -1,12 +1,16 @@
 package com.stylemycloset.weather.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.location.Location;
 import com.stylemycloset.location.LocationRepository;
+import com.stylemycloset.notification.event.domain.WeatherAlertEvent;
 import com.stylemycloset.weather.dto.WeatherDto;
 import com.stylemycloset.weather.entity.Humidity;
 import com.stylemycloset.weather.entity.Precipitation;
@@ -21,11 +25,13 @@ import com.stylemycloset.weather.repository.WeatherRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -127,7 +133,7 @@ public class WeatherServiceTest {
         assertEquals(todayWeather, result.get());
     }
 
-    /*@Test
+    @Test
     @DisplayName("AlertIsTriggered=true일때 pushlishEvent 작동")
     void checkWeather_shouldPublishEvent_whenAlertIsTriggered() {
         // given
@@ -144,7 +150,7 @@ public class WeatherServiceTest {
         when(weatherRepository.findByLocation(lat, lon)).thenReturn(List.of(weather));
 
         // when
-        weatherService.checkWeather(lat, lon);
+        weatherService.checkWeather(lat, lon, 1L);
 
         // then
         ArgumentCaptor<WeatherAlertEvent> eventCaptor = ArgumentCaptor.forClass(WeatherAlertEvent.class);
@@ -166,9 +172,9 @@ public class WeatherServiceTest {
 
         // when & then
         assertThrows(StyleMyClosetException.class, () ->
-            weatherService.checkWeather(lat, lon)
+            weatherService.checkWeather(lat, lon, 1L)
         );
-    }*/
+    }
 
 
 }


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [ ]  user 역할 변경 
- [ ] 피드 댓글 생성 / 좋아요 추가 / 피드 생성 시
- [ ] DM 보낼 시
- [ ] 팔로우할 시 
- [ ] 급격한 날씨 변화 시
- [ ] 테스트 코드에도 적용.

### 변경 사항 상세

### 1. 무엇을 변경했는지

- 이벤트 발행 코드를 추가함.
- 테스트 코드에도 적용

### 2. 왜 변경했는지

- 각 로직이 실행될 경우 알림을 생성하고 전송해주기 위하여

### 참고 사항
1. FeedControllerTest
피드엔 새 피드 생성 / 댓글 생성 / 좋아요 추가 시 이벤트 발행이 됩니다.
그런데 이벤트 리스너엔 `@TransactionalEventListener`이 붙어있어 테스트 환경에선 적용이 안 됩니다. 왜냐면 클래스에 있는 @Transactional 덕분에 테스트가 끝나면 롤백이 되기 떄문에 이벤트가 무시되기 때문입니다.

-> `@Transactional(propagation = Propagation.NOT_SUPPORTED)` 를 적용해서 이벤트까지 실행이 되게 하였는데, 이렇게 될 시 테스트 트랜잭션을 아예 없애고 테스트 db에 진짜 커밋이 되어버립니다.
-> 문제는 이렇게 될 시 유니크 제약이 걸어져 있는 데이터를 또 생성하려 하면 에러가 납니다.
-> 사용자, 옷 카테고리, 옷장은 이미 데이터가 있다면 재사용하고, 없다면 새로 생성하도록 하였습니다.
그래서 setUp() 부분을 아예 변경했어요.

2. 날씨 이벤트 발행 관련 컨트롤러 테스트
- 기존에 준혁님께서 작성하신 코드에 크게 영향을 주지 않으려는 선에서 바꾸려다 보니 제대로 못한 것 같긴 합니다. 그런데 직접 바꾸기엔 너무 코드가...어려워서...나중에 준혁님께서 적용을 해주셔야 할 것 같아요.
- 그래도 서비스 단위 테스트에선 준혁님께서 미리 만들어주신 코드가 있어 제대로 검증하였습니다.

### 3. 변경으로 인한 효과

<!-- 성능 개선, 사용성 향상 등 변경의 효과를 작성해주세요 -->

## ✅ 테스트 결과

### 테스트 코드 실행 결과

- 전체 테스트 코드 실행 결과
<img width="3622" height="1058" alt="image" src="https://github.com/user-attachments/assets/6a298e9a-6c35-444b-b316-096df553b5b2" />

## 🎯 리뷰 포인트

- [ ]  테스트 로직에 문제가 될 것 같은 부분이 있다면 말해주세요.


## 💭 추가 고려사항

<!-- 향후 개선이 필요한 부분이나 트레이드오프 사항을 작성해주세요 -->


Closes #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 실시간 알림 도입: 쪽지 전송, 팔로우, 피드 생성/좋아요/댓글 시 즉시 알림이 전송됩니다.
  - 사용자 맞춤 날씨 경보: 내 계정 기준으로 날씨 이상 상황 발생 시 알림을 제공합니다.
- 변경 사항
  - 날씨 조회 기능이 로그인 사용자 컨텍스트를 사용합니다. 이용 시 로그인이 필요합니다.
- 테스트
  - 알림 및 이벤트 발행 흐름에 대한 통합/단위 테스트가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->