### PR TITLE
[선혜린 | 0814] AuthenticationPrincipal 적용 (옷 기능 제외)

### DIFF
--- a/src/main/java/com/stylemycloset/directmessage/controller/DirectMessageController.java
+++ b/src/main/java/com/stylemycloset/directmessage/controller/DirectMessageController.java
@@ -6,6 +6,7 @@ import com.stylemycloset.directmessage.dto.request.DirectMessageSearchCondition;
 import com.stylemycloset.directmessage.dto.response.DirectMessageResponse;
 import com.stylemycloset.directmessage.entity.DirectMessageKey;
 import com.stylemycloset.directmessage.service.DirectMessageService;
+import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,10 +36,10 @@ public class DirectMessageController {
   @GetMapping("/api/direct-messages")
   public ResponseEntity<DirectMessageResponse<DirectMessageResult>> getDirectMessageByUser(
       @Valid DirectMessageSearchCondition condition,
-      @AuthenticationPrincipal Long viewerId // 시큐리티 수정 후 추가 예정
+      @AuthenticationPrincipal ClosetUserDetails principal
   ) {
     DirectMessageResponse<DirectMessageResult> messages = directMessageService.getDirectMessageBetweenParticipants(
-        condition, viewerId);
+        condition, principal.getUserId());
     return ResponseEntity.ok(messages);
   }
 

--- a/src/main/java/com/stylemycloset/directmessage/controller/DirectMessageController.java
+++ b/src/main/java/com/stylemycloset/directmessage/controller/DirectMessageController.java
@@ -1,17 +1,17 @@
 package com.stylemycloset.directmessage.controller;
 
-import com.stylemycloset.directmessage.dto.request.DirectMessageCreateRequest;
 import com.stylemycloset.directmessage.dto.DirectMessageResult;
+import com.stylemycloset.directmessage.dto.request.DirectMessageCreateRequest;
 import com.stylemycloset.directmessage.dto.request.DirectMessageSearchCondition;
 import com.stylemycloset.directmessage.dto.response.DirectMessageResponse;
 import com.stylemycloset.directmessage.entity.DirectMessageKey;
 import com.stylemycloset.directmessage.service.DirectMessageService;
-import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,12 +34,13 @@ public class DirectMessageController {
   }
 
   @GetMapping("/api/direct-messages")
+  @PreAuthorize("isAuthenticated()")
   public ResponseEntity<DirectMessageResponse<DirectMessageResult>> getDirectMessageByUser(
       @Valid DirectMessageSearchCondition condition,
-      @AuthenticationPrincipal ClosetUserDetails principal
+      @AuthenticationPrincipal(expression = "userId") Long viewerId
   ) {
     DirectMessageResponse<DirectMessageResult> messages = directMessageService.getDirectMessageBetweenParticipants(
-        condition, principal.getUserId());
+        condition, viewerId);
     return ResponseEntity.ok(messages);
   }
 

--- a/src/main/java/com/stylemycloset/follow/controller/FollowController.java
+++ b/src/main/java/com/stylemycloset/follow/controller/FollowController.java
@@ -7,6 +7,7 @@ import com.stylemycloset.follow.dto.request.FollowCreateRequest;
 import com.stylemycloset.follow.dto.request.SearchFollowersCondition;
 import com.stylemycloset.follow.dto.request.SearchFollowingsCondition;
 import com.stylemycloset.follow.service.FollowService;
+import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,9 +40,9 @@ public class FollowController {
   @GetMapping("/summary")
   public ResponseEntity<FollowSummaryResult> getFollowSummaryResult(
       @RequestParam(value = "userId") Long userId,
-      @AuthenticationPrincipal Long logInUserId // 시큐리티 추가시 넣을 예정
+      @AuthenticationPrincipal ClosetUserDetails principal // 시큐리티 추가시 넣을 예정
   ) {
-    FollowSummaryResult followSummaryResult = followService.getFollowSummary(userId, logInUserId);
+    FollowSummaryResult followSummaryResult = followService.getFollowSummary(userId, principal.getUserId());
     return ResponseEntity.ok(followSummaryResult);
   }
 

--- a/src/main/java/com/stylemycloset/follow/controller/FollowController.java
+++ b/src/main/java/com/stylemycloset/follow/controller/FollowController.java
@@ -7,10 +7,10 @@ import com.stylemycloset.follow.dto.request.FollowCreateRequest;
 import com.stylemycloset.follow.dto.request.SearchFollowersCondition;
 import com.stylemycloset.follow.dto.request.SearchFollowingsCondition;
 import com.stylemycloset.follow.service.FollowService;
-import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,11 +38,12 @@ public class FollowController {
   }
 
   @GetMapping("/summary")
+  @PreAuthorize("isAuthenticated()")
   public ResponseEntity<FollowSummaryResult> getFollowSummaryResult(
       @RequestParam(value = "userId") Long userId,
-      @AuthenticationPrincipal ClosetUserDetails principal // 시큐리티 추가시 넣을 예정
+      @AuthenticationPrincipal(expression = "userId") Long logInUserId
   ) {
-    FollowSummaryResult followSummaryResult = followService.getFollowSummary(userId, principal.getUserId());
+    FollowSummaryResult followSummaryResult = followService.getFollowSummary(userId, logInUserId);
     return ResponseEntity.ok(followSummaryResult);
   }
 

--- a/src/main/java/com/stylemycloset/notification/controller/NotificationController.java
+++ b/src/main/java/com/stylemycloset/notification/controller/NotificationController.java
@@ -3,9 +3,11 @@ package com.stylemycloset.notification.controller;
 import com.stylemycloset.notification.dto.NotificationDtoCursorResponse;
 import com.stylemycloset.notification.dto.NotificationFindAllRequest;
 import com.stylemycloset.notification.service.NotificationService;
+import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,23 +21,21 @@ public class NotificationController {
 
   private final NotificationService notificationService;
 
-  @DeleteMapping("/{receiverId}/{notificationId}")
+  @DeleteMapping("/{notificationId}")
   public ResponseEntity<Void> delete(
-      // UserDetails의 userId로 대체 예정.
-      @PathVariable long receiverId,
+      @AuthenticationPrincipal ClosetUserDetails principal,
       @PathVariable long notificationId
   ) {
-    notificationService.delete(receiverId, notificationId);
+    notificationService.delete(principal.getUserId(), notificationId);
     return ResponseEntity.noContent().build();
   }
 
-  @GetMapping("/{userId}")
+  @GetMapping()
   public ResponseEntity<NotificationDtoCursorResponse> findAllByReceiverId(
-      // UserDetails의 userId로 대체 예정.
-      @PathVariable long userId,
+      @AuthenticationPrincipal ClosetUserDetails principal,
       @Valid NotificationFindAllRequest request
   ) {
-    NotificationDtoCursorResponse res = notificationService.findAllByCursor(userId, request);
+    NotificationDtoCursorResponse res = notificationService.findAllByCursor(principal.getUserId(), request);
     return ResponseEntity.ok().body(res);
   }
 }

--- a/src/main/java/com/stylemycloset/notification/controller/NotificationController.java
+++ b/src/main/java/com/stylemycloset/notification/controller/NotificationController.java
@@ -3,10 +3,10 @@ package com.stylemycloset.notification.controller;
 import com.stylemycloset.notification.dto.NotificationDtoCursorResponse;
 import com.stylemycloset.notification.dto.NotificationFindAllRequest;
 import com.stylemycloset.notification.service.NotificationService;
-import com.stylemycloset.security.ClosetUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,20 +22,21 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   @DeleteMapping("/{notificationId}")
+  @PreAuthorize("isAuthenticated()")
   public ResponseEntity<Void> delete(
-      @AuthenticationPrincipal ClosetUserDetails principal,
+      @AuthenticationPrincipal(expression = "userId") Long userId,
       @PathVariable long notificationId
   ) {
-    notificationService.delete(principal.getUserId(), notificationId);
+    notificationService.delete(userId, notificationId);
     return ResponseEntity.noContent().build();
   }
 
   @GetMapping()
   public ResponseEntity<NotificationDtoCursorResponse> findAllByReceiverId(
-      @AuthenticationPrincipal ClosetUserDetails principal,
+      @AuthenticationPrincipal(expression = "userId") Long userId,
       @Valid NotificationFindAllRequest request
   ) {
-    NotificationDtoCursorResponse res = notificationService.findAllByCursor(principal.getUserId(), request);
+    NotificationDtoCursorResponse res = notificationService.findAllByCursor(userId, request);
     return ResponseEntity.ok().body(res);
   }
 }

--- a/src/main/java/com/stylemycloset/sse/controller/SseController.java
+++ b/src/main/java/com/stylemycloset/sse/controller/SseController.java
@@ -1,10 +1,11 @@
 package com.stylemycloset.sse.controller;
 
+import com.stylemycloset.security.ClosetUserDetails;
 import com.stylemycloset.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,13 +18,12 @@ public class SseController {
 
   private final SseService sseService;
 
-  @GetMapping(path = "/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter connect(
-      // UserDetails 구현체 생성될 시 수정 필요 (UserDetails의 user 관련 정보로 대체)
-      @PathVariable Long userId,
+      @AuthenticationPrincipal ClosetUserDetails principal,
       @RequestParam(value = "lastEventId", required = false) String lastEventId
   ) {
     String eventId = String.valueOf(System.currentTimeMillis());
-    return sseService.connect(userId, eventId, lastEventId);
+    return sseService.connect(principal.getUserId(), eventId, lastEventId);
   }
 }

--- a/src/main/java/com/stylemycloset/sse/controller/SseController.java
+++ b/src/main/java/com/stylemycloset/sse/controller/SseController.java
@@ -1,9 +1,9 @@
 package com.stylemycloset.sse.controller;
 
-import com.stylemycloset.security.ClosetUserDetails;
 import com.stylemycloset.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,11 +19,12 @@ public class SseController {
   private final SseService sseService;
 
   @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @PreAuthorize("isAuthenticated()")
   public SseEmitter connect(
-      @AuthenticationPrincipal ClosetUserDetails principal,
+      @AuthenticationPrincipal(expression = "userId") Long userId,
       @RequestParam(value = "lastEventId", required = false) String lastEventId
   ) {
     String eventId = String.valueOf(System.currentTimeMillis());
-    return sseService.connect(principal.getUserId(), eventId, lastEventId);
+    return sseService.connect(userId, eventId, lastEventId);
   }
 }

--- a/src/main/java/com/stylemycloset/sse/service/SseService.java
+++ b/src/main/java/com/stylemycloset/sse/service/SseService.java
@@ -9,7 +9,4 @@ public interface SseService {
 
   void sendNotification(NotificationDto notificationDto);
 
-  void cleanUpSseEmitters();
-
-  void cleanUpSseInfos();
 }

--- a/src/main/java/com/stylemycloset/weather/controller/WeatherController.java
+++ b/src/main/java/com/stylemycloset/weather/controller/WeatherController.java
@@ -1,12 +1,12 @@
 package com.stylemycloset.weather.controller;
 
-import com.stylemycloset.security.ClosetUserDetails;
 import com.stylemycloset.weather.dto.WeatherAPILocation;
 import com.stylemycloset.weather.dto.WeatherDto;
 import com.stylemycloset.weather.service.WeatherService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,12 +21,13 @@ public class WeatherController {
     private final WeatherService weatherService;
 
     @GetMapping
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<WeatherDto>> getWeathers(
         @RequestParam double latitude,
         @RequestParam double longitude,
-        @AuthenticationPrincipal ClosetUserDetails principal
+        @AuthenticationPrincipal(expression = "userId") Long userId
     ) {
-        weatherService.checkWeather(latitude, longitude, principal.getUserId());
+        weatherService.checkWeather(latitude, longitude, userId);
         List<WeatherDto> weathers = weatherService.getWeatherByCoordinates(latitude, longitude);
         return ResponseEntity.ok(weathers);
     }

--- a/src/test/java/com/stylemycloset/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/stylemycloset/follow/controller/FollowControllerTest.java
@@ -2,12 +2,13 @@ package com.stylemycloset.follow.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 
+import com.stylemycloset.ControllerTestSupport;
 import com.stylemycloset.follow.dto.FollowListResponse;
 import com.stylemycloset.follow.dto.FollowResult;
 import com.stylemycloset.follow.dto.FollowSummaryResult;
 import com.stylemycloset.follow.dto.request.FollowCreateRequest;
 import com.stylemycloset.follow.service.FollowService;
-import com.stylemycloset.ControllerTestSupport;
+import com.stylemycloset.security.ClosetUserDetails;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,8 @@ import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
@@ -22,6 +25,18 @@ class FollowControllerTest extends ControllerTestSupport {
 
   @MockitoBean
   private FollowService followService;
+
+  void setSecurityContext() {
+    ClosetUserDetails principal = new ClosetUserDetails(2L, "USER", "test");
+    var auth = new UsernamePasswordAuthenticationToken(principal, "test", principal.getAuthorities());
+    var context  = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(auth);
+    SecurityContextHolder.setContext(context);
+  }
+
+  void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
 
   @Test
   @DisplayName("팔로우 생성: 필수값 누락이면 400")
@@ -77,6 +92,7 @@ class FollowControllerTest extends ControllerTestSupport {
   @DisplayName("요약 조회: id 정상 전달이면 200")
   void summary_valid_returns200() {
     // given
+    setSecurityContext();
     BDDMockito.given(followService.getFollowSummary(any(), any()))
         .willReturn(Mockito.mock(FollowSummaryResult.class));
 
@@ -88,6 +104,8 @@ class FollowControllerTest extends ControllerTestSupport {
 
     // then
     Assertions.assertThat(result).hasStatus(HttpStatus.OK);
+
+    clearSecurityContext();
   }
 
   @Test

--- a/src/test/java/com/stylemycloset/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/stylemycloset/notification/controller/NotificationControllerTest.java
@@ -1,5 +1,6 @@
 package com.stylemycloset.notification.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -9,13 +10,24 @@ import com.stylemycloset.notification.entity.Notification;
 import com.stylemycloset.notification.entity.NotificationLevel;
 import com.stylemycloset.notification.repository.NotificationRepository;
 import com.stylemycloset.IntegrationTestSupport;
+import com.stylemycloset.user.dto.data.UserDto;
+import com.stylemycloset.user.entity.Role;
 import com.stylemycloset.user.entity.User;
+import com.stylemycloset.user.mapper.UserMapper;
 import com.stylemycloset.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,44 +42,64 @@ public class NotificationControllerTest extends IntegrationTestSupport {
   @Autowired
   NotificationRepository notificationRepository;
 
-  @Autowired
-  UserRepository userRepository;
+  @MockitoBean
+  private UserRepository userRepository;
+
+  @MockitoBean
+  UserMapper userMapper;
+
+  Long userId  = 1L;
+
+  @BeforeEach
+  void setup() {
+    User user = new User("testuser", "testuser@test.com", "testuser");
+    ReflectionTestUtils.setField(user, "id", userId);
+    UserDto dto = new UserDto(
+        user.getId(),
+        Instant.parse("2025-08-13T07:00:00Z"),
+        user.getEmail(),
+        user.getName(),
+        Role.USER,
+        List.of(),
+        false
+    );
+
+    given(userRepository.findByEmail("testuser@test.com"))
+        .willReturn(Optional.of(user));
+    given(userMapper.UsertoUserDto(user)).willReturn(dto);
+  }
 
   @DisplayName("알림 삭제 요청을 보낼 시 204응답이 온다")
+  @WithUserDetails(value = "testuser@test.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
   @Test
   void deleteNotifications_ReturnIsNoContent() throws Exception{
     // given
-    User user1 = userRepository.save(new User("test", "test@test.test", "test"));
-
     Notification notification = notificationRepository.save(
-        new Notification(user1.getId(), "testTitle", "testContent", NotificationLevel.INFO));
+        new Notification(userId, "testTitle", "testContent", NotificationLevel.INFO));
 
     // when & then
     mockMvc.perform(
-        delete("/api/notifications/{receiverId}/{notificationId}",
-            user1.getId(), notification.getId()))
+        delete("/api/notifications/{notificationId}", notification.getId()))
         .andExpect(status().isNoContent());
   }
 
   @DisplayName("알림 조회 요청을 보낼 시 NotificationDtoCursorResponse가 응답으로 온다")
+  @WithUserDetails(value = "testuser@test.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
   @Test
   void findAllByReceiverId_shouldReturnNotificationDtoCursorResponse() throws Exception{
     // given
-    User user4 = new User("test", "test@test.test", "test");
-    userRepository.save(user4);
-
     notificationRepository.save(
-        new Notification(user4.getId(), "testTitle", "testContent", NotificationLevel.INFO));
+        new Notification(userId, "testTitle", "testContent", NotificationLevel.INFO));
     notificationRepository.save(
-        new Notification(user4.getId(), "testTitle", "testContent", NotificationLevel.INFO));
+        new Notification(userId, "testTitle", "testContent", NotificationLevel.INFO));
     notificationRepository.save(
-        new Notification(user4.getId(), "testTitle", "testContent", NotificationLevel.INFO));
+        new Notification(userId, "testTitle", "testContent", NotificationLevel.INFO));
 
     notificationRepository.flush();
 
     // when & then
     mockMvc.perform(
-        get("/api/notifications/{userId}", user4.getId())
+        get("/api/notifications")
             .param("limit", String.valueOf(2))
     ).andExpect(status().isOk())
         .andExpect(jsonPath("$.hasNext").value(true))

--- a/src/test/java/com/stylemycloset/ootd/controller/FeedControllerTest.java
+++ b/src/test/java/com/stylemycloset/ootd/controller/FeedControllerTest.java
@@ -2,6 +2,7 @@ package com.stylemycloset.ootd.controller;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -29,6 +30,7 @@ import com.stylemycloset.ootd.entity.FeedLike;
 import com.stylemycloset.ootd.repo.FeedCommentRepository;
 import com.stylemycloset.ootd.repo.FeedLikeRepository;
 import com.stylemycloset.ootd.repo.FeedRepository;
+import com.stylemycloset.security.ClosetUserDetails;
 import com.stylemycloset.sse.service.SseService;
 import com.stylemycloset.user.entity.Role;
 import com.stylemycloset.user.entity.User;
@@ -121,6 +123,10 @@ public class FeedControllerTest extends IntegrationTestSupport {
     return clothRepository.save(c);
   }
 
+  private ClosetUserDetails createUserDetails() {
+    return new ClosetUserDetails(testUser.getId(), "USER", testUser.getName());
+  }
+
   @Nested
   @DisplayName("피드 생성 및 조회 API")
   class FeedCreateAndGet {
@@ -128,7 +134,6 @@ public class FeedControllerTest extends IntegrationTestSupport {
     @Test
     @DisplayName("새로운 OOTD 피드를 등록하면 201 Created 상태와 함께 피드 정보를 반환한다")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @WithMockUser
     void createFeed_Returns201AndFeedDto() throws Exception {
       // given (준비)
       List<Long> clothesIds = List.of(testCloth1.getId(), testCloth2.getId());
@@ -136,11 +141,14 @@ public class FeedControllerTest extends IntegrationTestSupport {
           "통합 테스트 피드 내용");
       String requestJson = objectMapper.writeValueAsString(request);
 
+      ClosetUserDetails userDetails = createUserDetails();
+
       // when & then (실행 및 검증)
       mockMvc.perform(post("/api/feeds")
               .contentType(MediaType.APPLICATION_JSON)
               .content(requestJson)
-              .with(csrf()))
+              .with(csrf())
+              .with(user(userDetails)))
           .andDo(print())
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.content").value("통합 테스트 피드 내용"))
@@ -171,12 +179,14 @@ public class FeedControllerTest extends IntegrationTestSupport {
   @Test
   @DisplayName("좋아요 토글 - 성공 시 (좋아요 추가) 200 OK와 업데이트된 피드 정보를 반환한다")
   @Transactional(propagation = Propagation.NOT_SUPPORTED)
-  @WithMockUser
   void toggleLike_whenNotLiked_returnsOkWithFeedDto() throws Exception {
     Feed feed = feedRepository.save(Feed.createFeed(testUser, null, "좋아요 테스트용 피드"));
 
+    ClosetUserDetails principal = createUserDetails();
+
     mockMvc.perform(post("/api/feeds/{feedId}/like", feed.getId())
-            .with(csrf()))
+            .with(csrf())
+            .with(user(principal)))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.likedByMe").value(true))
@@ -185,13 +195,15 @@ public class FeedControllerTest extends IntegrationTestSupport {
 
   @Test
   @DisplayName("좋아요 토글 - 성공 시 (좋아요 취소) 200 OK와 업데이트된 피드 정보를 반환한다")
-  @WithMockUser
   void toggleLike_whenAlreadyLiked_returnsOkWithFeedDto() throws Exception {
     Feed feed = feedRepository.save(Feed.createFeed(testUser, null, "좋아요 테스트용 피드"));
     feedLikeRepository.save(FeedLike.createFeedLike(testUser, feed));
 
+    ClosetUserDetails principal = createUserDetails();
+
     mockMvc.perform(post("/api/feeds/{feedId}/like", feed.getId())
-            .with(csrf()))
+            .with(csrf())
+            .with(user(principal)))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.likedByMe").value(false))
@@ -204,16 +216,18 @@ public class FeedControllerTest extends IntegrationTestSupport {
 
     @Test
     @DisplayName("자신이 작성한 피드의 내용을 수정하면 200 OK와 함께 피드 정보를 반환한다.")
-    @WithMockUser
     void updateFeed_Success() throws Exception {
       Feed myFeed = feedRepository.save(Feed.createFeed(testUser, null, "수정 전 피드 내용"));
       FeedUpdateRequest request = new FeedUpdateRequest("수정 후 새로운 피드 내용");
       String requestJson = objectMapper.writeValueAsString(request);
 
+      ClosetUserDetails principal = createUserDetails();
+
       mockMvc.perform(patch("/api/feeds/{feedId}", myFeed.getId())
               .contentType(MediaType.APPLICATION_JSON)
               .content(requestJson)
-              .with(csrf()))
+              .with(csrf())
+              .with(user(principal)))
           .andDo(print())
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.id").value(myFeed.getId()))
@@ -222,18 +236,20 @@ public class FeedControllerTest extends IntegrationTestSupport {
 
     @Test
     @DisplayName("피드 내용을 비워서 수정 요청하면 400 Bad Request 상태를 반환한다")
-    @WithMockUser
     void updateFeed_Fail_InvalidRequest() throws Exception {
       // given
       Feed myFeed = feedRepository.save(Feed.createFeed(testUser, null, "원래 내용"));
       FeedUpdateRequest request = new FeedUpdateRequest(" "); // 공백 문자열
       String requestJson = objectMapper.writeValueAsString(request);
 
+      ClosetUserDetails principal = createUserDetails();
+
       // when & then
       mockMvc.perform(patch("/api/feeds/{feedId}", myFeed.getId())
               .contentType(MediaType.APPLICATION_JSON)
               .content(requestJson)
-              .with(csrf()))
+              .with(csrf())
+              .with(user(principal)))
           .andDo(print())
           .andExpect(status().isBadRequest());
     }
@@ -242,12 +258,14 @@ public class FeedControllerTest extends IntegrationTestSupport {
 
   @Test
   @DisplayName("피드 삭제 API - 자신이 작성한 피드를 삭제하면 204 No Content 상태를 반환")
-  @WithMockUser
   void deleteFeed_Success() throws Exception {
     Feed myFeed = feedRepository.save(Feed.createFeed(testUser, null, "삭제될 피드"));
 
+    ClosetUserDetails principal = createUserDetails();
+
     mockMvc.perform(delete("/api/feeds/{feedId}", myFeed.getId())
-            .with(csrf()))
+            .with(csrf())
+            .with(user(principal)))
         .andDo(print())
         .andExpect(status().isNoContent());
 
@@ -306,7 +324,6 @@ public class FeedControllerTest extends IntegrationTestSupport {
     @Test
     @DisplayName("새로운 댓글을 등록하면 201 Created 상태와 함께 생성된 댓글 정보를 반환한다")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @WithMockUser
     void createComment_Success() throws Exception {
       // given (준비)
       // 1. 댓글을 달 피드 생성
@@ -320,11 +337,14 @@ public class FeedControllerTest extends IntegrationTestSupport {
       );
       String requestJson = objectMapper.writeValueAsString(request);
 
+      ClosetUserDetails principal = createUserDetails();
+
       // when & then (실행 및 검증)
       mockMvc.perform(post("/api/feeds/{feedId}/comments", feed.getId())
               .contentType(MediaType.APPLICATION_JSON)
               .content(requestJson)
-              .with(csrf()))
+              .with(csrf())
+              .with(user(principal)))
           .andDo(print())
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.content").value("새로운 댓글입니다!"))
@@ -334,7 +354,6 @@ public class FeedControllerTest extends IntegrationTestSupport {
 
     @Test
     @DisplayName("댓글 내용이 비어있는 요청을 보내면 400 Bad Request를 반환한다")
-    @WithMockUser
     void createComment_Fail_BlankContent() throws Exception {
       // given
       Feed feed = feedRepository.save(Feed.createFeed(testUser, null, "댓글 등록용 피드"));
@@ -343,11 +362,14 @@ public class FeedControllerTest extends IntegrationTestSupport {
           " "); // 내용이 공백
       String requestJson = objectMapper.writeValueAsString(request);
 
+      ClosetUserDetails principal = createUserDetails();
+
       // when & then
       mockMvc.perform(post("/api/feeds/{feedId}/comments", feed.getId())
               .contentType(MediaType.APPLICATION_JSON)
               .content(requestJson)
-              .with(csrf()))
+              .with(csrf())
+              .with(user(principal)))
           .andDo(print())
           .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/stylemycloset/sse/controller/SseControllerTest.java
+++ b/src/test/java/com/stylemycloset/sse/controller/SseControllerTest.java
@@ -1,55 +1,82 @@
-package com.stylemycloset.sse;
+package com.stylemycloset.sse.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
-import com.stylemycloset.sse.service.SseService;
-import com.stylemycloset.IntegrationTestSupport;
+import com.stylemycloset.user.dto.data.UserDto;
+import com.stylemycloset.user.entity.Role;
+import com.stylemycloset.user.entity.User;
+import com.stylemycloset.user.mapper.UserMapper;
+import com.stylemycloset.user.repository.UserRepository;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Profile("test")
 public class SseControllerTest extends IntegrationTestSupport {
 
   @Autowired
   MockMvc mockMvc;
 
   @Autowired
-  SseService sseService;
-
-  @Autowired
   SseRepository sseRepository;
 
+  @MockitoBean
+  private UserRepository userRepository;
+
+  @MockitoBean
+  UserMapper userMapper;
+
+  @BeforeEach
+  void setup() {
+    User user = new User("testuser", "testuser@test.com", "testuser");
+    ReflectionTestUtils.setField(user, "id", 1L);
+    UserDto dto = new UserDto(
+        user.getId(),
+        Instant.parse("2025-08-13T07:00:00Z"),
+        user.getEmail(),
+        user.getName(),
+        Role.USER,
+        List.of(),
+        false
+    );
+
+    given(userRepository.findByEmail("testuser@test.com"))
+        .willReturn(Optional.of(user));
+    given(userMapper.UsertoUserDto(user)).willReturn(dto);
+  }
+
   @DisplayName("lastEventId 없이 SSE 연결 요청을 보내면 SSE 연결 응답을 반환한다")
-  @WithMockUser(username = "testuser", roles = "USER")
+  @WithUserDetails(value = "testuser@test.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
   @Test
   public void sseConnect_returnSseEmitter() throws Exception {
-    // given
-    Long userId = 1L;
-
-    // when & then
-    mockMvc.perform(get("/api/sse/{userId}", userId)
+    mockMvc.perform(get("/api/sse")
             .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
         .andExpect(status().isOk())
         .andExpect(header().string("content-type", org.hamcrest.Matchers.containsString(MediaType.TEXT_EVENT_STREAM_VALUE)));
   }
 
   @DisplayName("lastEventId를 포함하여 SSE 연결 요청을 보내면 놓친 알림 데이터를 전송하고, SSE 연결 응답을 반환한다")
-  @WithMockUser(username = "testuser", roles = "USER")
+  @WithUserDetails(value = "testuser@test.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
   @Test
   public void sseReconnect_shouldReplayMissedEvents() throws Exception {
     // given
@@ -62,7 +89,7 @@ public class SseControllerTest extends IntegrationTestSupport {
     sseRepository.findOrCreateEvents(userId).addAll(sseInfos);
 
     // when & then
-    mockMvc.perform(get("/api/sse/{userId}", userId)
+    mockMvc.perform(get("/api/sse")
             .param("lastEventId", "1754037511000")
             .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
         .andExpect(status().isOk())
@@ -72,12 +99,10 @@ public class SseControllerTest extends IntegrationTestSupport {
   }
 
   @DisplayName("잘못된 형식의 lastEventId를 포함하여 SSE 연결 요청을 보내면 경고 로그를 보낸다")
-  @WithMockUser(username = "testuser", roles = "USER")
+  @WithUserDetails(value = "testuser@test.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
   @Test
   public void sseReconnect_withInvalidLastEventId_shouldWriteWarnLog() throws Exception {
-    long userId = 1L;
-
-    mockMvc.perform(get("/api/sse/{userId}", userId)
+    mockMvc.perform(get("/api/sse")
             .param("lastEventId", "1754037511000L")
             .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
         .andExpect(status().isOk());


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항
[인증에서 userId 가져온 적용]
- [ ]  ootd
- [ ] sse
- [ ] notificaiton
- [ ] follow
- [ ] dm

### 변경 사항 상세

### 1. 무엇을 변경했는지

- UserDetails에서 가져온 userId를 사용하는 곳들을 변경

### 2. 왜 변경했는지

[컨트롤러 테스트 변경점]
1. sse, notificaiton : 실제 인증 흐름까지 검증하도록 함.
2. ootd : 이미 연관 엔티티를 생성하고 이벤트 발행까지 적용되고 있어서 .with()를 사용하여 간단하게 컨트롤러 동작이 되도록 함.
3. follow : MockMvcTester에다가 WebMvvTest여서 인증 빈이 뜨지 않고 with()를 사용할 수 없었기에 직접 SecurityContext를 채워 작성함.
4. dm : 컨트롤러 테스트가 존재하지 않아 패스함.

## ✅ 테스트 결과

### 테스트 코드 실행 결과

- 전체 테스트 결과 : 정상적으로 돌아감.
<img width="2006" height="955" alt="image" src="https://github.com/user-attachments/assets/35f3f5f5-4f3a-4352-8993-7f4e73d879d0" />


## 🎯 리뷰 포인트

- [ ] 테스트 코드의 인증 부분에서 더 좋은 방법으로 변경할 방법이 있다면 말해주십시오.


Closes #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능/변경**
  - 모든 DM/팔로우/알림/피드/SSE API가 인증된 로그인 사용자(userId)를 자동으로 사용하도록 인증 연동을 통일했습니다.
  - 여러 쓰기/수정/삭제 엔드포인트에 인증 필요(로그인) 제약이 추가되었습니다.
  - 피드 작성 시 요청의 authorId가 로그인 사용자와 다르면 400 Bad Request를 반환합니다.
  - 알림 및 SSE 관련 엔드포인트 경로가 간소화되었습니다 (경로 기반 userId 제거).
- **테스트**
  - 변경된 인증 흐름과 엔드포인트를 반영해 테스트들을 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->