### PR TITLE
[선혜린 | 0815] Sse 자료구조 변경 및 동시성 제어

### DIFF
--- a/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
+++ b/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
@@ -14,21 +14,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Repository
 public class SseRepository {
 
-  private final Map<Long, Deque<SseEmitter>> userEmitters;
-  private final Map<Long, Deque<SseInfo>> userEvents;
-
-  public SseRepository() {
-    this.userEmitters = new ConcurrentHashMap<>();
-    this.userEvents = new ConcurrentHashMap<>();
-  }
-
-  public SseRepository(
-      Map<Long, Deque<SseEmitter>> userEmitters,
-      Map<Long, Deque<SseInfo>> userEvents
-  ) {
-    this.userEmitters = userEmitters;
-    this.userEvents = userEvents;
-  }
+  private final ConcurrentHashMap<Long, Deque<SseEmitter>> userEmitters = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, Deque<SseInfo>> userEvents = new ConcurrentHashMap<>();
 
   private static final int MAX_EMITTER_COUNT = 3;
   private static final int MAX_EVENT_COUNT = 30;

--- a/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
+++ b/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
@@ -14,8 +14,21 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Repository
 public class SseRepository {
 
-  private final ConcurrentHashMap<Long, Deque<SseEmitter>> userEmitters = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Long, Deque<SseInfo>> userEvents = new ConcurrentHashMap<>();
+  private final Map<Long, Deque<SseEmitter>> userEmitters;
+  private final Map<Long, Deque<SseInfo>> userEvents;
+
+  public SseRepository() {
+    this.userEmitters = new ConcurrentHashMap<>();
+    this.userEvents = new ConcurrentHashMap<>();
+  }
+
+  public SseRepository(
+      Map<Long, Deque<SseEmitter>> userEmitters,
+      Map<Long, Deque<SseInfo>> userEvents
+  ) {
+    this.userEmitters = userEmitters;
+    this.userEvents = userEvents;
+  }
 
   private static final int MAX_EMITTER_COUNT = 3;
   private static final int MAX_EVENT_COUNT = 30;

--- a/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
+++ b/src/main/java/com/stylemycloset/sse/repository/SseRepository.java
@@ -1,26 +1,37 @@
 package com.stylemycloset.sse.repository;
 
 import com.stylemycloset.sse.dto.SseInfo;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Repository
 public class SseRepository {
 
-  private final ConcurrentHashMap<Long, CopyOnWriteArrayList<SseEmitter>> userEmitters = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<Long, ConcurrentLinkedDeque<SseInfo>> userEvents = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, Deque<SseEmitter>> userEmitters = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, Deque<SseInfo>> userEvents = new ConcurrentHashMap<>();
 
-  public void addEmitter(Long userId, SseEmitter emitter) {
-    userEmitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+  private static final int MAX_EMITTER_COUNT = 3;
+  private static final int MAX_EVENT_COUNT = 30;
+
+  public SseEmitter addEmitter(Long userId, SseEmitter emitter) {
+    final SseEmitter[] completeEmitter = {null};
+    userEmitters.compute(userId, (id, emitters) -> {
+      Deque<SseEmitter> emitterList = (emitters == null) ? new ArrayDeque<>() : emitters;
+      if(emitterList.size() >= MAX_EMITTER_COUNT) {
+        completeEmitter[0] = emitterList.removeFirst();
+      }
+      emitterList.addLast(emitter);
+      return emitterList;
+    });
+
+    return completeEmitter[0];
   }
 
   public void removeEmitter(Long userId, SseEmitter emitter) {
@@ -31,25 +42,44 @@ public class SseRepository {
   }
 
   public Map<Long, List<SseEmitter>> findAllEmittersReadOnly() {
-    return userEmitters.entrySet().stream()
-        .collect(Collectors.toMap(
-            Map.Entry::getKey,
-            entry -> Collections.unmodifiableList(entry.getValue())
-        ));
+    Map<Long, List<SseEmitter>> result = new HashMap<>();
+    for(Long userId : userEmitters.keySet()) {
+      userEmitters.compute(userId, (id, emitters) -> {
+        if(emitters != null && !emitters.isEmpty()) {
+          result.put(id, List.copyOf(emitters));
+        }
+        return emitters;
+      });
+    }
+    return Collections.unmodifiableMap(result);
   }
 
-  public CopyOnWriteArrayList<SseEmitter> findOrCreateEmitters(Long userId) {
-    return userEmitters.computeIfAbsent(userId, k -> new CopyOnWriteArrayList<>());
+  public Deque<SseEmitter> findOrCreateEmitters(Long userId) {
+    return userEmitters.computeIfAbsent(userId, k -> new ArrayDeque<>());
+  }
+
+  public void addEvent(Long userId, SseInfo event) {
+    userEvents.compute(userId, (id, events) -> {
+      Deque<SseInfo> eventQueue = (events == null) ? new ArrayDeque<>() : events;
+      if(eventQueue.size() >= MAX_EVENT_COUNT) {
+        eventQueue.removeFirst();
+      }
+      eventQueue.addLast(event);
+      return eventQueue;
+    });
   }
 
   public Deque<SseInfo> findOrCreateEvents(Long userId) {
-    return userEvents.computeIfAbsent(userId, k -> new ConcurrentLinkedDeque<>());
+    return userEvents.computeIfAbsent(userId, k -> new ArrayDeque<>());
   }
 
   public void cleanEventOlderThan(long timeout) {
-    userEvents.forEach((userId, events) -> {
+    for(Long userId : userEvents.keySet()) {
+      userEvents.compute(userId, (id, events) -> {
+        if(events == null) return null;
         events.removeIf(event -> event.createdAt() < timeout);
-        if(events.isEmpty()) userEvents.remove(userId, events);
-    });
+        return events.isEmpty() ? null : events;
+      });
+    }
   }
 }

--- a/src/test/java/com/stylemycloset/notification/event/listener/FeedCommentNotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/stylemycloset/notification/event/listener/FeedCommentNotificationEventListenerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.notification.entity.Notification;
 import com.stylemycloset.notification.entity.NotificationLevel;
 import com.stylemycloset.notification.event.domain.FeedCommentEvent;
@@ -15,16 +16,13 @@ import com.stylemycloset.notification.util.NotificationStubHelper;
 import com.stylemycloset.notification.util.TestUserFactory;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.repo.FeedRepository;
-import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
 import com.stylemycloset.sse.service.impl.SseServiceImpl;
-import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -67,13 +65,11 @@ public class FeedCommentNotificationEventListenerIntegrationTest extends Integra
     given(userRepository.findById(commentUser.getId())).willReturn(Optional.of(commentUser));
     NotificationStubHelper.stubSave(notificationRepository);
 
-    CopyOnWriteArrayList<SseEmitter> list1 = new CopyOnWriteArrayList<>();
-    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
+    Deque<SseEmitter> list1 = new ArrayDeque<>();
+
     willAnswer(inv -> { list1.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(user.getId()), any(SseEmitter.class));
-
-    Deque<SseInfo> queue1 = new ConcurrentLinkedDeque<>();
-    given(sseRepository.findOrCreateEvents(user.getId())).willReturn(queue1);
+    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
 
     String now = String.valueOf(System.currentTimeMillis());
     sseService.connect(user.getId(), now, null);
@@ -93,6 +89,5 @@ public class FeedCommentNotificationEventListenerIntegrationTest extends Integra
     assertThat(saved.getCreatedAt()).isNotNull();
     assertThat(saved.getTitle()).isEqualTo("commentUsername님이 댓글을 달았어요.");
     assertThat(saved.getLevel()).isEqualTo(NotificationLevel.INFO);
-    assertThat(queue1).isNotEmpty();
   }
 }

--- a/src/test/java/com/stylemycloset/notification/event/listener/FeedLikedNotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/stylemycloset/notification/event/listener/FeedLikedNotificationEventListenerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.notification.entity.Notification;
 import com.stylemycloset.notification.entity.NotificationLevel;
 import com.stylemycloset.notification.event.domain.FeedLikedEvent;
@@ -15,16 +16,13 @@ import com.stylemycloset.notification.util.NotificationStubHelper;
 import com.stylemycloset.notification.util.TestUserFactory;
 import com.stylemycloset.ootd.entity.Feed;
 import com.stylemycloset.ootd.repo.FeedRepository;
-import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
 import com.stylemycloset.sse.service.impl.SseServiceImpl;
-import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -67,13 +65,11 @@ public class FeedLikedNotificationEventListenerIntegrationTest extends Integrati
     given(userRepository.findById(likeUser.getId())).willReturn(Optional.of(likeUser));
     NotificationStubHelper.stubSave(notificationRepository);
 
-    CopyOnWriteArrayList<SseEmitter> list1 = new CopyOnWriteArrayList<>();
-    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
+    Deque<SseEmitter> list1 = new ArrayDeque<>();
+
     willAnswer(inv -> { list1.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(user.getId()), any(SseEmitter.class));
-
-    Deque<SseInfo> queue1 = new ConcurrentLinkedDeque<>();
-    given(sseRepository.findOrCreateEvents(user.getId())).willReturn(queue1);
+    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
 
     String now = String.valueOf(System.currentTimeMillis());
     sseService.connect(user.getId(), now, null);
@@ -93,6 +89,5 @@ public class FeedLikedNotificationEventListenerIntegrationTest extends Integrati
     assertThat(saved.getCreatedAt()).isNotNull();
     assertThat(saved.getTitle()).isEqualTo("likeUsername님이 내 피드를 좋아합니다.");
     assertThat(saved.getLevel()).isEqualTo(NotificationLevel.INFO);
-    assertThat(queue1).isNotEmpty();
   }
 }

--- a/src/test/java/com/stylemycloset/notification/event/listener/NewClothAttributeNotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/stylemycloset/notification/event/listener/NewClothAttributeNotificationEventListenerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.stylemycloset.notification.event.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -8,20 +7,18 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.notification.event.domain.NewClothAttributeEvent;
 import com.stylemycloset.notification.repository.NotificationRepository;
 import com.stylemycloset.notification.util.NotificationStubHelper;
 import com.stylemycloset.notification.util.TestUserFactory;
-import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
 import com.stylemycloset.sse.service.impl.SseServiceImpl;
-import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,19 +53,16 @@ public class NewClothAttributeNotificationEventListenerIntegrationTest extends I
     given(userRepository.findActiveUserIds()).willReturn(users);
     NotificationStubHelper.stubSaveAll(notificationRepository);
 
-    CopyOnWriteArrayList<SseEmitter> list1 = new CopyOnWriteArrayList<>();
-    CopyOnWriteArrayList<SseEmitter> list2 = new CopyOnWriteArrayList<>();
-    given(sseRepository.findOrCreateEmitters(insertUser1.getId())).willReturn(list1);
-    given(sseRepository.findOrCreateEmitters(insertUser2.getId())).willReturn(list2);
+    Deque<SseEmitter> list1 = new ArrayDeque<>();
+    Deque<SseEmitter> list2 = new ArrayDeque<>();
+
     willAnswer(inv -> { list1.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(insertUser1.getId()), any(SseEmitter.class));
     willAnswer(inv -> { list2.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(insertUser2.getId()), any(SseEmitter.class));
 
-    Deque<SseInfo> queue1 = new ConcurrentLinkedDeque<>();
-    Deque<SseInfo> queue2 = new ConcurrentLinkedDeque<>();
-    given(sseRepository.findOrCreateEvents(insertUser1.getId())).willReturn(queue1);
-    given(sseRepository.findOrCreateEvents(insertUser2.getId())).willReturn(queue2);
+    given(sseRepository.findOrCreateEmitters(insertUser1.getId())).willReturn(list1);
+    given(sseRepository.findOrCreateEmitters(insertUser2.getId())).willReturn(list2);
 
     String now = String.valueOf(System.currentTimeMillis());
     sseService.connect(insertUser1.getId(), now, null);
@@ -81,8 +75,6 @@ public class NewClothAttributeNotificationEventListenerIntegrationTest extends I
 
     // then
     verify(notificationRepository).saveAll(anyList());
-    assertThat(queue1).isNotEmpty();
-    assertThat(queue2).isNotEmpty();
   }
 
 }

--- a/src/test/java/com/stylemycloset/notification/event/listener/NewFeedNotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/stylemycloset/notification/event/listener/NewFeedNotificationEventListenerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.stylemycloset.notification.event.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -8,22 +7,20 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.follow.repository.FollowRepository;
 import com.stylemycloset.notification.event.domain.NewFeedEvent;
 import com.stylemycloset.notification.repository.NotificationRepository;
 import com.stylemycloset.notification.util.NotificationStubHelper;
 import com.stylemycloset.notification.util.TestUserFactory;
-import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
 import com.stylemycloset.sse.service.impl.SseServiceImpl;
-import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,19 +60,16 @@ public class NewFeedNotificationEventListenerIntegrationTest extends Integration
     given(followRepository.findFollowerIdsByFolloweeId(feedAuthor.getId())).willReturn(receivers);
     NotificationStubHelper.stubSaveAll(notificationRepository);
 
-    CopyOnWriteArrayList<SseEmitter> list1 = new CopyOnWriteArrayList<>();
-    CopyOnWriteArrayList<SseEmitter> list2 = new CopyOnWriteArrayList<>();
-    given(sseRepository.findOrCreateEmitters(follower1.getId())).willReturn(list1);
-    given(sseRepository.findOrCreateEmitters(follower2.getId())).willReturn(list2);
+    Deque<SseEmitter> list1 = new ArrayDeque<>();
+    Deque<SseEmitter> list2 = new ArrayDeque<>();
+
     willAnswer(inv -> { list1.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(follower1.getId()), any(SseEmitter.class));
     willAnswer(inv -> { list2.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(follower2.getId()), any(SseEmitter.class));
 
-    Deque<SseInfo> queue1 = new ConcurrentLinkedDeque<>();
-    Deque<SseInfo> queue2 = new ConcurrentLinkedDeque<>();
-    given(sseRepository.findOrCreateEvents(follower1.getId())).willReturn(queue1);
-    given(sseRepository.findOrCreateEvents(follower2.getId())).willReturn(queue2);
+    given(sseRepository.findOrCreateEmitters(follower1.getId())).willReturn(list1);
+    given(sseRepository.findOrCreateEmitters(follower2.getId())).willReturn(list2);
 
     String now = String.valueOf(System.currentTimeMillis());
     sseService.connect(follower1.getId(), now, null);
@@ -88,7 +82,5 @@ public class NewFeedNotificationEventListenerIntegrationTest extends Integration
 
     // then
     verify(notificationRepository).saveAll(anyList());
-    assertThat(queue1).isNotEmpty();
-    assertThat(queue2).isNotEmpty();
   }
 }

--- a/src/test/java/com/stylemycloset/notification/event/listener/RoleChangedNotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/stylemycloset/notification/event/listener/RoleChangedNotificationEventListenerIntegrationTest.java
@@ -7,23 +7,21 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.notification.entity.Notification;
 import com.stylemycloset.notification.entity.NotificationLevel;
 import com.stylemycloset.notification.event.domain.RoleChangedEvent;
 import com.stylemycloset.notification.repository.NotificationRepository;
 import com.stylemycloset.notification.util.NotificationStubHelper;
 import com.stylemycloset.notification.util.TestUserFactory;
-import com.stylemycloset.sse.dto.SseInfo;
 import com.stylemycloset.sse.repository.SseRepository;
 import com.stylemycloset.sse.service.impl.SseServiceImpl;
-import com.stylemycloset.IntegrationTestSupport;
 import com.stylemycloset.user.entity.Role;
 import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.repository.UserRepository;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -59,13 +57,11 @@ public class RoleChangedNotificationEventListenerIntegrationTest extends Integra
     given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
     NotificationStubHelper.stubSave(notificationRepository);
 
-    CopyOnWriteArrayList<SseEmitter> list1 = new CopyOnWriteArrayList<>();
-    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
+    Deque<SseEmitter> list1 = new ArrayDeque<>();
+
     willAnswer(inv -> { list1.add(inv.getArgument(1)); return null; })
         .given(sseRepository).addEmitter(eq(user.getId()), any(SseEmitter.class));
-
-    Deque<SseInfo> queue1 = new ConcurrentLinkedDeque<>();
-    given(sseRepository.findOrCreateEvents(user.getId())).willReturn(queue1);
+    given(sseRepository.findOrCreateEmitters(user.getId())).willReturn(list1);
 
     String now = String.valueOf(System.currentTimeMillis());
     sseService.connect(user.getId(), now, null);
@@ -85,6 +81,5 @@ public class RoleChangedNotificationEventListenerIntegrationTest extends Integra
     assertThat(saved.getCreatedAt()).isNotNull();
     assertThat(saved.getTitle()).isEqualTo("내 권한이 변경되었어요.");
     assertThat(saved.getLevel()).isEqualTo(NotificationLevel.INFO);
-    assertThat(queue1).isNotEmpty();
   }
 }

--- a/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
@@ -8,12 +8,9 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +19,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public class SseRepositoryUnitTest {
 
-  private static final Logger log = LogManager.getLogger(SseRepositoryUnitTest.class);
   SseRepository sseRepository;
 
   static final int MAX_EMITTER_COUNT = 3;
@@ -133,7 +129,6 @@ public class SseRepositoryUnitTest {
     int loops = 1000;
 
     ExecutorService pool = Executors.newFixedThreadPool(10);
-    CountDownLatch doneLatch = new CountDownLatch(loops);
     List<Future<?>> futures = new ArrayList<>();
 
     // when
@@ -158,7 +153,6 @@ public class SseRepositoryUnitTest {
   @DisplayName("같은 userId에 대해 여러 스레드가 동시에 addEmitter()를 호출해도 예외가 발생하지 않고 데이터가 저장된다.")
   @Test
   void addEmitter_differentUserIds_parallelism_observed() throws Exception {
-    int loops = 1000;
 
     ExecutorService pool = Executors.newFixedThreadPool(10);
     List<Future<?>> futures = new ArrayList<>();

--- a/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
@@ -1,8 +1,117 @@
 package com.stylemycloset.sse.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.stylemycloset.sse.dto.SseInfo;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
 public class SseRepositoryUnitTest {
 
-  // @DisplayName("Emitter 개수가 MAX_EMITTER_COUNT 미만이면 바로 Emitter를 저장한다.")
-  // @DisplayName("Emitter개수가 MAX_EMITTER_COUNT이상이면 가장 오래된 emitter를 제거하고 저장한다.")
-  // @DisplayName("이벤트 개수가 MAX_EVENT_COUNT 이상이면 가장 오래된 이벤트를 제거하고 저장한다.")
+  private static final Logger log = LoggerFactory.getLogger(SseRepositoryUnitTest.class);
+  SseRepository sseRepository;
+
+  static final int MAX_EMITTER_COUNT = 3;
+  static final int MAX_EVENT_COUNT = 30;
+  Long userId = 100L;
+
+  @BeforeEach
+  void setUp() {
+    sseRepository = new SseRepository();
+  }
+
+  @SuppressWarnings("unchecked")
+  Deque<SseEmitter> getEmitters(Long userId) {
+    Map<Long, Deque<SseEmitter>> userEmitters =
+        (Map<Long, Deque<SseEmitter>>) ReflectionTestUtils.getField(sseRepository, "userEmitters");
+    return userEmitters.getOrDefault(userId, new ArrayDeque<>());
+  }
+
+  @SuppressWarnings("unchecked")
+  Deque<SseInfo> getEvents(Long userId) {
+    Map<Long, Deque<SseInfo>> userEvents =
+        (Map<Long, Deque<SseInfo>>) ReflectionTestUtils.getField(sseRepository, "userEvents");
+    return userEvents.getOrDefault(userId, new ArrayDeque<>());
+  }
+
+  @DisplayName("Emitter 개수가 MAX_EMITTER_COUNT 미만이면 바로 Emitter를 저장하고 null을 반환한다.")
+  @Test
+  void addEmitter_whenBelowMax_shouldJustStore() {
+    // given
+    SseEmitter emitter = new SseEmitter();
+
+    // when
+    SseEmitter completedEmitter = sseRepository.addEmitter(userId, emitter);
+
+    // then
+    Deque<SseEmitter> emitters = getEmitters(userId);
+    assertThat(completedEmitter).isNull();
+    assertThat(emitters.getLast()).isSameAs(emitter);
+  }
+
+  @DisplayName("Emitter개수가 MAX_EMITTER_COUNT이상이면 가장 오래된 emitter를 제거하고 저장한다.")
+  @Test
+  void addEmitter_whenOverMax_shouldRemoveOldestAndAdd() {
+    // given
+    SseEmitter emitter1 = new SseEmitter();
+    SseEmitter emitter2 = new SseEmitter();
+    SseEmitter emitter3 = new SseEmitter();
+
+    sseRepository.addEmitter(userId, emitter1);
+    sseRepository.addEmitter(userId, emitter2);
+    sseRepository.addEmitter(userId, emitter3);
+
+    // when
+    SseEmitter eNew = new SseEmitter(600_000L);
+    SseEmitter completedEmitter = sseRepository.addEmitter(userId, eNew);
+
+    // then
+    assertThat(completedEmitter).isSameAs(emitter1);
+
+    Deque<SseEmitter> emitters = getEmitters(userId);
+    assertThat(emitters).hasSize(MAX_EMITTER_COUNT);
+    assertThat(emitters.peekFirst()).isSameAs(emitter2);
+    assertThat(emitters.peekLast()).isSameAs(eNew);
+
+  }
+
+  @DisplayName("이벤트 개수가 MAX_EVENT_COUNT 미만이면 바로 SseInfo를 저장한다.")
+  @Test
+  void addEvent_whenBelowMax_shouldJustStore() {
+    // given
+    SseInfo event = new SseInfo(1, "test", "test", 1);
+
+    // when
+    sseRepository.addEvent(userId, event);
+
+    // then
+    Deque<SseInfo> events = getEvents(userId);
+    assertThat(events.getLast()).isSameAs(event);
+  }
+
+  @DisplayName("이벤트 개수가 MAX_EVENT_COUNT 이상이면 가장 오래된 이벤트를 제거하고 저장한다.")
+  @Test
+  void addEvent_whenOverMax_shouldRemoveOldestAndAdd() {
+    // given
+    for (int i = 0; i < MAX_EVENT_COUNT; i++) {
+      sseRepository.addEvent(userId, new SseInfo((long) i, "test", "test" + i, i));
+    }
+
+    // when
+    SseInfo newEvent = new SseInfo(3L, "test", "newTest", 3L);
+    sseRepository.addEvent(userId, newEvent);
+
+    // then
+    Deque<SseInfo> events = getEvents(userId);
+    assertThat(events).hasSize(MAX_EVENT_COUNT);
+    assertThat(events.getLast()).isSameAs(newEvent);
+  }
 }

--- a/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
@@ -1,0 +1,8 @@
+package com.stylemycloset.sse.repository;
+
+public class SseRepositoryUnitTest {
+
+  // @DisplayName("Emitter 개수가 MAX_EMITTER_COUNT 미만이면 바로 Emitter를 저장한다.")
+  // @DisplayName("Emitter개수가 MAX_EMITTER_COUNT이상이면 가장 오래된 emitter를 제거하고 저장한다.")
+  // @DisplayName("이벤트 개수가 MAX_EVENT_COUNT 이상이면 가장 오래된 이벤트를 제거하고 저장한다.")
+}

--- a/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
@@ -108,13 +108,18 @@ public class SseRepositoryUnitTest {
     }
 
     // when
-    SseInfo newEvent = new SseInfo(3L, "test", "newTest", 3L);
+    SseInfo newEvent = new SseInfo(30L, "test", "newTest", 3L);
     sseRepository.addEvent(userId, newEvent);
 
     // then
     Deque<SseInfo> events = getEvents(userId);
     assertThat(events).hasSize(MAX_EVENT_COUNT);
     assertThat(events.getLast()).isSameAs(newEvent);
+
+    int expectedId = 1;
+    for(SseInfo event : events) {
+      assertThat(event.id()).isEqualTo(expectedId++);
+    }
   }
 
   @DisplayName("같은 userId에 대해 동시 다발 addEvent()를 호출해도 30개만 정확히 남는다.")

--- a/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/repository/SseRepositoryUnitTest.java
@@ -6,22 +6,24 @@ import com.stylemycloset.sse.dto.SseInfo;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public class SseRepositoryUnitTest {
 
-  private static final Logger log = LoggerFactory.getLogger(SseRepositoryUnitTest.class);
   SseRepository sseRepository;
 
   static final int MAX_EMITTER_COUNT = 3;
   static final int MAX_EVENT_COUNT = 30;
   Long userId = 100L;
+  Long userId2 = 101L;
 
   @BeforeEach
   void setUp() {
@@ -102,7 +104,7 @@ public class SseRepositoryUnitTest {
   void addEvent_whenOverMax_shouldRemoveOldestAndAdd() {
     // given
     for (int i = 0; i < MAX_EVENT_COUNT; i++) {
-      sseRepository.addEvent(userId, new SseInfo((long) i, "test", "test" + i, i));
+      sseRepository.addEvent(userId, new SseInfo(i, "test", "test" + i, i));
     }
 
     // when
@@ -114,4 +116,177 @@ public class SseRepositoryUnitTest {
     assertThat(events).hasSize(MAX_EVENT_COUNT);
     assertThat(events.getLast()).isSameAs(newEvent);
   }
+
+  @DisplayName("같은 userId에 대해 동시 다발 addEvent()를 호출해도 30개만 정확히 남는다.")
+  @Test
+  void addEvent_sameUserId_concurrent_writes_keep_last_30() throws Exception {
+    // given
+    int total = 60;
+    int threads = 20;
+
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(total);
+
+    // when
+    for (int i = 0; i < total; i++) {
+      final long eventId = i + 1;
+      pool.submit(() -> {
+        try{
+          startGate.await();
+          sseRepository.addEvent(userId, new SseInfo(eventId, "test", "test", 0));
+        } catch(InterruptedException e){
+          Thread.currentThread().interrupt();
+        } finally {
+          doneGate.countDown();
+        }
+      });
+    }
+
+    startGate.countDown();
+    doneGate.await();
+    pool.shutdown();
+
+    // then
+    Deque<SseInfo> events = getEvents(userId);
+    assertThat(events).hasSize(MAX_EVENT_COUNT);
+  }
+
+  @DisplayName("같은 userId에 대해 동시 다발 addEmitter()를 호출해도 마지막 3개만 정확히 남는다")
+  @Test
+  void addEmitter_sameUser_concurrent_keeps_last_3() throws Exception {
+    int total = 6;
+    int threads = 2;
+
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(total);
+
+    for (int i = 0; i < total; i++) {
+      pool.submit(() -> {
+        try {
+          startGate.await();
+          sseRepository.addEmitter(userId, new SseEmitter());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneGate.countDown();
+        }
+      });
+    }
+
+    startGate.countDown();
+    doneGate.await();
+    pool.shutdown();
+
+    Deque<SseEmitter> emitters = getEmitters(userId);
+    assertThat(emitters).hasSize(MAX_EMITTER_COUNT);
+  }
+
+  @DisplayName("userEvents의 addEmitter()는 서로 다른 userId에 대해서 병렬로 처리된다.")
+  @Test
+  void addEvent_differentUserIds_parallelism_observed()  throws Exception {
+    int loops = 31;
+
+    AtomicInteger threadCount = new AtomicInteger();
+    AtomicInteger maxThreadCount = new AtomicInteger();
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(2);
+
+    Runnable worker1 = makeEventWorker(userId, loops, threadCount, maxThreadCount, startGate, doneGate);
+    Runnable worker2 = makeEventWorker(userId2, loops, threadCount, maxThreadCount, startGate, doneGate);
+
+    pool.submit(worker1);
+    pool.submit(worker2);
+    startGate.countDown();
+    doneGate.await();
+    pool.shutdown();
+
+    assertThat(maxThreadCount.get()).isEqualTo(2);
+    assertThat(getEvents(userId)).hasSize(MAX_EVENT_COUNT);
+    assertThat(getEvents(userId2)).hasSize(MAX_EVENT_COUNT);
+  }
+
+  @DisplayName("userEvents의 addEmitter()는 서로 다른 userId에 대해서 병렬로 처리된다.")
+  @Test
+  void addEmitter_differentUserIds_parallelism_observed() throws Exception {
+    int loops = 31;
+
+    AtomicInteger threadCount = new AtomicInteger();
+    AtomicInteger maxThreadCount = new AtomicInteger();
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    CountDownLatch startGate = new CountDownLatch(1);
+    CountDownLatch doneGate = new CountDownLatch(2);
+
+    Runnable worker1 = makeEmitterWorker(userId, loops, threadCount, maxThreadCount, startGate, doneGate);
+    Runnable worker2 = makeEmitterWorker(userId2, loops, threadCount, maxThreadCount, startGate, doneGate);
+
+    pool.submit(worker1);
+    pool.submit(worker2);
+    startGate.countDown();
+    doneGate.await();
+    pool.shutdown();
+
+    assertThat(maxThreadCount.get()).isEqualTo(2);
+    assertThat(getEmitters(userId)).hasSize(MAX_EMITTER_COUNT);
+    assertThat(getEmitters(userId2)).hasSize(MAX_EMITTER_COUNT);
+  }
+
+  private Runnable makeEventWorker(
+      Long userId,
+      int loops,
+      AtomicInteger threadCount,
+      AtomicInteger maxThreadCount,
+      CountDownLatch startGate,
+      CountDownLatch doneGate) {
+    return () -> {
+      try {
+        startGate.await();
+        for (int i = 0; i < loops; i++) {
+          int now = threadCount.incrementAndGet();
+          maxThreadCount.updateAndGet(m -> Math.max(m, now));
+          try {
+            sseRepository.addEvent(userId, new SseInfo(i + 1,"test","test",0));
+          } finally {
+            threadCount.decrementAndGet();
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        doneGate.countDown();
+      }
+    };
+  }
+
+  private Runnable makeEmitterWorker(Long userId,
+      int loops,
+      AtomicInteger threadCount,
+      AtomicInteger maxThreadCount,
+      CountDownLatch startGate,
+      CountDownLatch doneGate) {
+    return () -> {
+      try {
+        startGate.await();
+        for (int i = 0; i < loops; i++) {
+          int now = threadCount.incrementAndGet();
+          maxThreadCount.updateAndGet(m -> Math.max(m, now));
+          try {
+            sseRepository.addEmitter(userId, new SseEmitter());
+          } finally {
+            threadCount.decrementAndGet();
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        doneGate.countDown();
+      }
+    };
+  }
+
+
 }

--- a/src/test/java/com/stylemycloset/sse/service/SseServiceUnitTest.java
+++ b/src/test/java/com/stylemycloset/sse/service/SseServiceUnitTest.java
@@ -1,11 +1,9 @@
 package com.stylemycloset.sse.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -20,8 +18,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArrayList;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,11 +26,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @ExtendWith(MockitoExtension.class)
 public class SseServiceUnitTest {
 
+  private static final Logger log = LoggerFactory.getLogger(SseServiceUnitTest.class);
   @Mock
   SseRepository sseRepository;
 
@@ -47,46 +46,36 @@ public class SseServiceUnitTest {
   private static final int MAX_EMITTER_COUNT = 3;
   private static final int MAX_EVENT_COUNT = 30;
 
-  @DisplayName("Emitter 개수가 MAX_EMITTER_COUNT 미만이고 lastEventId가 없다면 emitter를 저장한다.")
+  @DisplayName("lastEventId가 없다면 emitter를 저장한다.")
   @Test
   void connect_addNewEmitter_whenUnderLimit() throws Exception {
     // given
-    given(sseRepository.findOrCreateEmitters(111L)).willReturn(new CopyOnWriteArrayList<>());
+    Long userId = 111L;
+    given(sseRepository.addEmitter(any(Long.class), any(SseEmitter.class))).willReturn(null);
 
     // when
-    SseEmitter res = sseService.connect(111L, String.valueOf(1_726_000_000_000L), null);
+    SseEmitter res = sseService.connect(userId, String.valueOf(1_726_000_000_000L), null);
 
     // then
-    verify(sseRepository).addEmitter(111L, res);
+    verify(sseRepository).addEmitter(userId, res);
+    verify(sseSender).sendToClient(eq(userId), any(SseEmitter.class), any(String.class), eq("connect"), eq("Sse Connected"));
   }
 
-  @DisplayName("Emitter개수가 MAX_EMITTER_COUNT이상이면 가장 오래된 emitter를 제거하고 저장한다.")
+  @DisplayName("Emitter개수가 MAX_EMITTER_COUNT이상이면 가장 오래된 emitter를 제거한다.")
   @Test
   void connect_shouldRemoveOldestEmitterIfExceedsLimit() {
     // given
     Long userId = 9L;
 
-    CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
-    for (int i = 0; i < MAX_EMITTER_COUNT; i++) {
-      emitters.add(mock(SseEmitter.class));
-    }
-    SseEmitter oldest = emitters.getFirst();
-
-    given(sseRepository.findOrCreateEmitters(userId)).willReturn(emitters);
-    willAnswer(inv -> {
-      emitters.add(inv.getArgument(1));
-      return null;
-    }).given(sseRepository).addEmitter(eq(userId), any(SseEmitter.class));
+    SseEmitter emitter = mock(SseEmitter.class);
+    given(sseRepository.addEmitter(any(Long.class), any(SseEmitter.class))).willReturn(emitter);
 
     // when
-    SseEmitter newEmitter = sseService.connect(userId, String.valueOf(1_726_000_000_000L), null);
+    sseService.connect(userId, String.valueOf(1_726_000_000_000L), null);
 
     // then
-    assertAll(
-        () -> assertThat(emitters).hasSize(MAX_EMITTER_COUNT),
-        () -> assertThat(emitters).contains(newEmitter),
-        () -> assertThat(emitters).doesNotContain(oldest)
-    );
+    verify(emitter).complete();
+    verify(sseSender).sendToClient(eq(userId), any(SseEmitter.class), any(String.class), eq("connect"), eq("Sse Connected"));
   }
 
   @DisplayName("lastEventId와 함께 connect()를 호출하면 놓친 알림을 보낸다")
@@ -95,14 +84,8 @@ public class SseServiceUnitTest {
     // given
     Long userId = 1L;
     long lastEventId = 1L;
-    CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
-    given(sseRepository.findOrCreateEmitters(userId)).willReturn(emitters);
-    willAnswer(inv -> {
-      SseEmitter sseEmitter = inv.getArgument(1);
-      emitters.add(sseEmitter);
-      return null;
-    }).given(sseRepository).addEmitter(eq(userId), any(SseEmitter.class));
+    given(sseRepository.addEmitter(any(Long.class), any(SseEmitter.class))).willReturn(null);
 
     SseInfo sseInfo1 = new SseInfo(2L, "notifications", "데이터1", 2);
     SseInfo sseInfo2 = new SseInfo(3L, "notifications", "데이터2", 3);
@@ -130,26 +113,21 @@ public class SseServiceUnitTest {
     given(newNotification.receiverId()).willReturn(userId);
     given(newNotification.createdAt()).willReturn(Instant.now());
 
-    CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    Deque<SseEmitter> emitters = new ArrayDeque<>();
     emitters.add(mock(SseEmitter.class));
     given(sseRepository.findOrCreateEmitters(userId)).willReturn(emitters);
 
-    Deque<SseInfo> events = new ConcurrentLinkedDeque<>();
+    Deque<SseInfo> events = new ArrayDeque<>();
     for (int i = 0; i < MAX_EVENT_COUNT; i++) {
       events.add(new SseInfo(i, "notifications", mock(NotificationDto.class), 1L));
     }
     SseInfo oldest = events.getFirst();
-    given(sseRepository.findOrCreateEvents(userId)).willReturn(events);
-
     // when
     sseService.sendNotification(newNotification);
 
     // then
-    assertAll(
-        () -> assertThat(events).hasSize(MAX_EVENT_COUNT),
-        () -> assertThat(events.getLast().data()).isEqualTo(newNotification),
-        () -> assertThat(events).doesNotContain(oldest)
-    );
+    assertThat(events).hasSize(MAX_EVENT_COUNT);
+    verify(sseRepository).addEvent(eq(userId), any(SseInfo.class));
   }
 
   @DisplayName("sendNotification() 호출 시 userEvents에 이벤트가 저장된다")
@@ -162,10 +140,9 @@ public class SseServiceUnitTest {
 
     NotificationDto notificationDto = new NotificationDto(1L, createdAt, userId, "테스트1", "테스트1", NotificationLevel.INFO);
 
-    CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    Deque<SseEmitter> emitters = new ArrayDeque<>();
     emitters.add(mock(SseEmitter.class));
     given(sseRepository.findOrCreateEmitters(userId)).willReturn(emitters);
-    given(sseRepository.findOrCreateEvents(userId)).willReturn(new ConcurrentLinkedDeque<>());
 
     // when
     sseService.sendNotification(notificationDto);


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [ ]  Sse 자료구조 변경 및 동시성 제어

### 변경 사항 상세

### 1. 무엇을 변경했는지

1. SseEmitter를 저장하는 userEmitters와 알림 이벤트 저장하는 userEvents 자료 구조 변경
`ConcurrentHashMap<Long, Deque<SseEmitter>>`

2. 동시성 제어를 하기 위해 한 메서드 내에서 사이즈 확인 -> 삭제 -> 추가를 진행.

3. 해당 변경에 따른 메서드들과 테스트 수정.

4. SseRepository의 기본 생성자 및 테스트를 위한 생성자 추가.

### 2. 왜 변경했는지

기존의 저장 구조는 ConcurrentHashMap을 사용하여 동시성 제어를 하지 않음. 그래서 사이즈 확인 -> 삭제 -> 추가를 각각 진행. 이럴 경우 synchronized를 사용하여 묶을 수밖에 없었음. 그 결과 서로 다른 사용자의 요청도 동일한 락을 대기하게 되어 병목이 발생할 수 있었음.

->  ConcurrentHashMap은 키에 대해 동시성을 제어하기 때문에, 동일한 키(userId)에 대해서만 직렬화되고, 다른 키에 대해서는 병렬로 처리되어 처리량을 높일 수 있게 됨.
-> 이번 변경에서 람다를 사용해 compute() 내부에서 사이즈 확인 -> 삭제 -> 추가를 한 번에 수행. 

+ 동시성 제어 테스트 추가 
- 기존의 "서로 다른 userId에 대해서는 병렬로 수행되기에 각 userId에 대해 여러 호출(add~)이 들어와도 서로의 연산에 영향을 받지 않는다." 테스트는 동시성 제어를 테스트하지 않았고, concurrentHashMap자체를 테스트하는 성향이기에 addEvent()나 addEmitter() 자체를 테스트하려고 함.
- userEvent나 userEmitter가 HashMap이었을 경우 에러가 날 것을 검증하는 테스트를 추가하였습니다.

### 3. 변경으로 인한 효과

- emitter, 알림 event의 삭제, 추가를 안전하게 수행 가능.

## ✅ 테스트 결과

### 테스트 코드 실행 결과

- 여러 테스트를 변경하여 전체 테스트 코드 결과를 올렸습니다.
<img width="2062" height="754" alt="image" src="https://github.com/user-attachments/assets/65992157-3347-4ab9-801c-032a1b4438e0" />

- 동시성 테스트 결과
<img width="943" height="71" alt="image" src="https://github.com/user-attachments/assets/e81d7130-db22-494c-a2e7-8c39b4bfb81b" />

++ ConcurrentHashMap이 아닌, HashMap으로 작성되었을 시 동시성 제어가 되지 않음을 테스트함.
<img width="500" height="600" alt="image" src="https://github.com/user-attachments/assets/f3dc10d2-95de-4599-a455-7cefb15a3e9b" />

결과:
<img width="563" height="43" alt="image" src="https://github.com/user-attachments/assets/fd71a1cc-156c-48e4-ba2d-36521bfbde43" />
<img width="530" height="29" alt="image" src="https://github.com/user-attachments/assets/66c1bb7b-c012-48b8-836f-3ee3f316e6b7" />



## 🎯 리뷰 포인트

- [ ]  repository 메서드 중 add~()를 한 번 확인해주시고 이상하거나 의문점이 드는 점은 편하게 말해주세요.
- [ ]  동시성 테스트를 추가했는데, 부족하다면 어떤 점을 고려해서 검증해야 하는 지 조언해주십쇼.

Closes #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자별 연결과 이벤트 저장에 용량 제한을 도입해 자동으로 오래된 연결·이벤트를 교체합니다.

* **버그 수정**
  * 누락·지연 가능성을 추가로 줄여 실시간 알림 신뢰성을 개선했습니다.
  * 과도한 연결·이벤트 누적으로 인한 메모리·안정성 문제를 완화했습니다.

* **리팩터링**
  * 알림 전송 및 놓친 이벤트 재전송 흐름을 단순화해 일관성과 예측성을 향상시켰습니다.

* **테스트**
  * 통합·단위 테스트를 최신 동작에 맞게 보강해 회귀 방지를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->