### PR TITLE
[심민혁 | 0825] User에 location추가 로직

### DIFF
--- a/src/main/java/com/stylemycloset/user/dto/data/ProfileDto.java
+++ b/src/main/java/com/stylemycloset/user/dto/data/ProfileDto.java
@@ -2,6 +2,7 @@ package com.stylemycloset.user.dto.data;
 
 import com.stylemycloset.location.Location;
 import com.stylemycloset.user.entity.Gender;
+import com.stylemycloset.weather.dto.WeatherAPILocation;
 import java.time.LocalDate;
 
 public record ProfileDto(
@@ -9,7 +10,7 @@ public record ProfileDto(
     String name,
     Gender gender,
     LocalDate birthDate,
-    Location location,
+    WeatherAPILocation location,
     Integer temperatureSensitivity,
     String profileImageUrl
 ) {

--- a/src/main/java/com/stylemycloset/user/mapper/UserMapper.java
+++ b/src/main/java/com/stylemycloset/user/mapper/UserMapper.java
@@ -1,12 +1,18 @@
 package com.stylemycloset.user.mapper;
 
+import com.stylemycloset.location.mapper.LocationMapper;
 import com.stylemycloset.user.dto.data.ProfileDto;
 import com.stylemycloset.user.dto.data.UserDto;
 import com.stylemycloset.user.entity.User;
+import com.stylemycloset.weather.dto.WeatherAPILocation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class UserMapper {
+
+  private final LocationMapper locationMapper;
 
   public UserDto toUserDto(User user) {
     if (user == null) {
@@ -26,12 +32,16 @@ public class UserMapper {
     if (user == null) {
       return null;
     }
+    WeatherAPILocation locationDto = null;
+    if (user.getLocation() != null) {
+      locationDto = locationMapper.toDto(user.getLocation());
+    }
 
     return new ProfileDto(user.getId(),
         user.getName(),
         user.getGender(),
         user.getBirthDate(),
-        user.getLocation(),
+        locationDto,
         user.getTemperatureSensitivity(),
         profileImageUrl
     );

--- a/src/main/java/com/stylemycloset/user/service/UserServiceImpl.java
+++ b/src/main/java/com/stylemycloset/user/service/UserServiceImpl.java
@@ -3,6 +3,10 @@ package com.stylemycloset.user.service;
 import com.stylemycloset.binarycontent.entity.BinaryContent;
 import com.stylemycloset.binarycontent.repository.BinaryContentRepository;
 import com.stylemycloset.binarycontent.storage.BinaryContentStorage;
+import com.stylemycloset.common.exception.ErrorCode;
+import com.stylemycloset.common.exception.StyleMyClosetException;
+import com.stylemycloset.location.Location;
+import com.stylemycloset.location.LocationRepository;
 import com.stylemycloset.notification.event.domain.RoleChangedEvent;
 import com.stylemycloset.security.jwt.JwtService;
 import com.stylemycloset.user.dto.data.ProfileDto;
@@ -47,6 +51,7 @@ public class UserServiceImpl implements UserService {
   private final MailService mailSender;
   private final BinaryContentRepository binaryContentRepository;
   private final BinaryContentStorage storage;
+  private final LocationRepository locationRepository;
 
   @Transactional
   @Override
@@ -116,6 +121,22 @@ public class UserServiceImpl implements UserService {
   public ProfileDto updateProfile(Long userId, ProfileUpdateRequest request,
       MultipartFile image) {
     User user = findUserById(userId);
+    Location location = null;
+
+    if (request.location() != null) {
+      location = locationRepository.findByLatitudeAndLongitude(request.location().getLatitude(),
+              request.location().getLongitude())
+          .orElseGet(() -> {
+            Location newLocation = new Location(
+                request.location().getLatitude(),
+                request.location().getLongitude(),
+                request.location().getX(),
+                request.location().getY(),
+                request.location().getLocationNames()
+            );
+            return locationRepository.save(newLocation);
+          });
+    }
     String profileImageUrl = null;
     if (image != null && !image.isEmpty()) {
       try {
@@ -132,7 +153,7 @@ public class UserServiceImpl implements UserService {
       }
     }
 
-    user.updateProfile(request.name(), request.gender(), request.birthDate(), request.location(),
+    user.updateProfile(request.name(), request.gender(), request.birthDate(), location,
         request.temperatureSensitivity());
     if (user.getProfileImage() != null) {
       profileImageUrl = storage.getUrl(user.getProfileImage().getId()).toString();

--- a/src/test/java/com/stylemycloset/user/service/UserServiceTest.java
+++ b/src/test/java/com/stylemycloset/user/service/UserServiceTest.java
@@ -28,6 +28,7 @@ import com.stylemycloset.user.entity.User;
 import com.stylemycloset.user.mapper.UserMapper;
 import com.stylemycloset.user.repository.UserRepository;
 import com.stylemycloset.user.util.MailService;
+import com.stylemycloset.weather.dto.WeatherAPILocation;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.time.LocalDate;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.util.ReflectionUtils;
 import org.springframework.mock.web.MockMultipartFile;
@@ -361,12 +363,19 @@ public class UserServiceTest {
   }
 
   private ProfileDto createTestProfileDto(User user, String imageUrl) {
+    WeatherAPILocation location = null;
+    if (user.getLocation() != null) {
+      location = new WeatherAPILocation(user.getLocation().getLatitude(),
+          user.getLocation().getLongitude(), user.getLocation().getX(), user.getLocation().getY(),
+          user.getLocation().getLocationNames());
+    }
+
     return new ProfileDto(
         user.getId(),
         user.getName(),
         user.getGender(),
         user.getBirthDate(),
-        user.getLocation(),
+        location,
         user.getTemperatureSensitivity(),
         imageUrl
     );


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- Profile저장 시 location까지 user에 저장하는 로직 추가

### 변경 사항 상세

### 1. 무엇을 변경했는지

Profile저장 시 Location을 받아 User에 추가하여 해당 User의 지역을 추가하는 로직을 추가함

### 2. 왜 변경했는지

Location이 완성됨에 따라 User에 Location을 추가하는 로직을 추가함

### 3. 변경으로 인한 효과

Profile조회 시 이제 Location을 추가 하여 Profile을 업데이트하면 User에 해당 Location이 추가됨 + 다음 Profile조회 시 Location까지 보여줌

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<img width="866" height="256" alt="image" src="https://github.com/user-attachments/assets/792b8f31-f92d-4263-9d20-9ed124969301" />

## 🎯 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐야 할 부분을 체크리스트로 작성해주세요 -->

- [ ] 혹시 오류 날꺼 같은 부분 확인해주시면 감사하겠습니다.

## 🔄 **기능 흐름**

1. 사용자가 Location호출 api사용 ->
2. Profile업데이트 시 User에 Location이 저장됨 ->
3. 다음 Profile조회 시 Location까지 옴

## 📚 관련 위키

<!-- 트러블슈팅 내용이 담긴 위키 링크를 첨부해주세요 -->

## 💭 추가 고려사항



Closes #42