### PR TITLE
[허재석 | 0828] 추천 피드 등록시 필드명 불일치 오류

### DIFF
--- a/src/main/java/com/stylemycloset/recommendation/dto/ClothesDto.java
+++ b/src/main/java/com/stylemycloset/recommendation/dto/ClothesDto.java
@@ -3,7 +3,7 @@ package com.stylemycloset.recommendation.dto;
 import java.util.List;
 
 public record ClothesDto(
-    Long id,
+    Long clothesId,
     String name,
     String imageUrl,
     String type,

--- a/src/main/java/com/stylemycloset/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/stylemycloset/recommendation/service/RecommendationService.java
@@ -61,7 +61,7 @@ public class RecommendationService {
     if (clothes.size() < 10) {
       for (Clothes c : clothes) {
         if (!vectorCosineSimilarityMeter.recommend(c, weather, user)) {
-          current.clothes().removeIf(dto -> Objects.equals(dto.id(), c.getId()));
+          current.clothes().removeIf(dto -> Objects.equals(dto.clothesId(), c.getId()));
           result = current;
           if(!c.getSelectedValues().isEmpty()) {vectorCosineSimilarityMeter.recordFeedback(weather, user, c.getSelectedValues(), false);}
         } else {


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [ ]  ClothesDto 에서 id() 메서드 호출을 clothesId()로 로 수정하여 컴파일 오류를 해결 

### 변경 사항 상세

### 1. 무엇을 변경했는지

- [ ] ClothesDto 에서 id() 메서드 호출을 clothesId()로 변경
- [ ] RecommendationService 에서 ClothesDto 의 clothesId() 와 Clothes의 getId() 와 비교

### 2. 왜 변경했는지

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cefeff2c-b869-459f-b70e-08b360857c6b" />

- 피드 생성 시 clothesIds가 [null, null, null]로 전송되어 404 에러 발생
- 프론트엔드에서 추천 API 응답의 clothesId 필드를 기대하지만 백엔드에서는 id 필드만 제공

### 3. 변경으로 인한 효과

- 추천탭에서 OOTD 피드 등록 가능

## ✅ 테스트 결과

### 테스트 코드 실행 결과

<img width="574" height="139" alt="image" src="https://github.com/user-attachments/assets/4205086e-4762-47d6-9096-44f1a45ec824" />

<img width="650" height="637" alt="image" src="https://github.com/user-attachments/assets/53d4d203-f5e4-4bc0-b8f9-a7dfddc7ffcf" />


## 🎯 리뷰 포인트

- [ ] 다른 도메인에서 ClothesDto id 필드명을 사용하고 있었으면 충돌날 수 있지만 제가 지금확인해본 결과 RecommendationService 빼고는 없었습니다.

## 🔄 **기능 흐름**

1. ClothesDto는 Record이므로 clothesId 필드에 대해 clothesId() 메서드가 자동 생성됨
2. Clothes 엔티티는 id 필드에 대해 getId() 메서드를 가짐
3. 매퍼에서는 Clothes 엔티티의 getId()를 호출해서 ClothesDto의 clothesId 필드에 값을 넣어줌
4. 서비스에서는 ClothesDto 의 clotesId() 를 호출해서 Clothes 의 getId() 와 비교


## 📚 관련 위키


## 💭 추가 고려사항


Closes #113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 의류 DTO의 ID 필드명을 clothesId로 변경하여 명확성을 향상했습니다. 이에 따라 추천 처리 과정에서의 항목 식별·제거 로직을 일관되게 업데이트했습니다.
  - API를 사용하는 통합 환경에서는 기존 id 참조를 clothesId로 교체해야 합니다.

- Chores
  - 관련 코드 전반에서 새로운 필드명에 맞춰 참조를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->