### PR TITLE
fix: 위도경도 말고 xy 좌표로 찾기

### DIFF
--- a/src/main/java/com/stylemycloset/location/LocationRepository.java
+++ b/src/main/java/com/stylemycloset/location/LocationRepository.java
@@ -13,12 +13,12 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
     @Query(value = """
     SELECT *
     FROM locations l
-    WHERE ABS(l.latitude - :lat) < 0.01
-      AND ABS(l.longitude - :lon) < 0.01
+    WHERE ABS(l.y- :y) < 0.01
+      AND ABS(l.x - :x) < 0.01
     LIMIT 1
 """, nativeQuery = true)
-    Optional<Location> findByLatitudeAndLongitude(@Param("lat") double latitude,
-                                                  @Param("lon") double longitude);
+    Optional<Location> findByLatitudeAndLongitude(@Param("y") int y,
+                                                  @Param("x") int x);
 
     // 또는 범위 기반 조회 (실제 환경에서는 부동소수점 오차를 고려해 이 방식이 더 안전)
     Optional<Location> findTopByOrderByCreatedAtDesc();

--- a/src/main/java/com/stylemycloset/user/service/UserServiceImpl.java
+++ b/src/main/java/com/stylemycloset/user/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.stylemycloset.user.service;
 
+import static com.stylemycloset.location.util.LamcConverter.mapConv;
+
 import com.stylemycloset.binarycontent.entity.BinaryContent;
 import com.stylemycloset.binarycontent.repository.BinaryContentRepository;
 import com.stylemycloset.binarycontent.storage.s3.BinaryContentStorage;
@@ -123,8 +125,9 @@ public class UserServiceImpl implements UserService {
     Location location = null;
 
     if (request.location() != null) {
-      location = locationRepository.findByLatitudeAndLongitude(request.location().getLatitude(),
-              request.location().getLongitude())
+      double[] xy = mapConv(request.location().getLongitude(), request.location().getLatitude(), 0);
+      location = locationRepository.findByLatitudeAndLongitude((int)xy[1],
+              (int)xy[0])
           .orElseGet(() -> {
             Location newLocation = new Location(
                 request.location().getLatitude(),

--- a/src/main/java/com/stylemycloset/weather/batch/WeatherFetchTasklet.java
+++ b/src/main/java/com/stylemycloset/weather/batch/WeatherFetchTasklet.java
@@ -1,5 +1,7 @@
 package com.stylemycloset.weather.batch;
 
+import static com.stylemycloset.location.util.LamcConverter.mapConv;
+
 import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.location.Location;
@@ -42,7 +44,9 @@ public class WeatherFetchTasklet implements Tasklet {
         double lat = latestLocationOpt.map(Location::getLatitude).orElse(DEFAULT_LATITUDE);
         double lon = latestLocationOpt.map(Location::getLongitude).orElse(DEFAULT_LONGITUDE);
 
-        Location location = locationRepository.findByLatitudeAndLongitude(lat,lon).orElseGet(
+        double[] xy = mapConv(lon, lat, 0);
+
+        Location location = locationRepository.findByLatitudeAndLongitude((int)xy[1],(int)xy[0]).orElseGet(
             ()->kakaoApiService.createLocation(lon,lat)  );
 
         Optional.ofNullable(location)

--- a/src/main/java/com/stylemycloset/weather/service/WeatherServiceImpl.java
+++ b/src/main/java/com/stylemycloset/weather/service/WeatherServiceImpl.java
@@ -1,5 +1,7 @@
 package com.stylemycloset.weather.service;
 
+import static com.stylemycloset.location.util.LamcConverter.mapConv;
+
 import com.stylemycloset.common.exception.ErrorCode;
 import com.stylemycloset.common.exception.StyleMyClosetException;
 import com.stylemycloset.location.Location;
@@ -43,7 +45,9 @@ public class WeatherServiceImpl implements WeatherService {
 
         List<Weather> weathers = getTheNext5DaysByLocation(latitude, longitude);
         if(weathers.isEmpty()){
-            Location location = locationRepository.findByLatitudeAndLongitude(latitude,longitude).orElseGet(
+            double[] xy = mapConv(longitude, latitude, 0);
+
+            Location location = locationRepository.findByLatitudeAndLongitude((int)xy[1],(int)xy[0]).orElseGet(
                 ()->kakaoApiService.createLocation(longitude,latitude)  );
             weathers = forecastApiService.fetchData(location);
             weatherRepository.saveAll(weathers);
@@ -54,7 +58,9 @@ public class WeatherServiceImpl implements WeatherService {
     }
 
     public WeatherAPILocation getLocation(double latitude, double longitude) {
-        Location location = locationRepository.findByLatitudeAndLongitude(latitude,longitude).orElseGet(
+        double[] xy = mapConv(longitude, latitude, 0);
+
+        Location location = locationRepository.findByLatitudeAndLongitude((int)xy[1],(int)xy[0]).orElseGet(
             ()->kakaoApiService.createLocation(longitude,latitude)  );
         return locationMapper.toDto(location);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 좌표 변환을 적용해 기존 위경도 매칭 오류로 발생하던 위치/날씨 조회 실패를 개선했습니다.
  - 주변 좌표 탐색 정밀도를 높여 더 정확한 위치 매칭이 이뤄지도록 했습니다.
  - 위치가 없을 때의 생성 처리 흐름을 보완해 실패 가능성을 줄였습니다.
- 리팩터링
  - 위치 조회 로직을 변환 좌표 기반으로 통일하고, 사용자 프로필/날씨 조회/배치 작업 전반에서 일관되게 사용하도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->