### PR TITLE
[선혜린 | 0928] DM, follow목록, DM 알림 문제 수정

### DIFF
--- a/src/main/java/com/stylemycloset/follow/controller/FollowController.java
+++ b/src/main/java/com/stylemycloset/follow/controller/FollowController.java
@@ -55,7 +55,7 @@ public class FollowController {
     return ResponseEntity.ok(followings);
   }
 
-  @GetMapping("/follower")
+  @GetMapping("/followers")
   public ResponseEntity<FollowListResponse<FollowResult>> getFollowers(
       @Valid @ModelAttribute SearchFollowersCondition followersCondition
   ) {

--- a/src/main/java/com/stylemycloset/notification/event/listener/DMReceivedNotificationEventListener.java
+++ b/src/main/java/com/stylemycloset/notification/event/listener/DMReceivedNotificationEventListener.java
@@ -35,7 +35,7 @@ public class DMReceivedNotificationEventListener {
     try {
       String title = String.format(NEW_MESSAGE, event.sendUsername());
       NotificationDto dto = notificationService.create(message.getReceiver().getId(),
-          title, "", NotificationLevel.INFO);
+          title, message.getContent(), NotificationLevel.INFO);
 
       streamPublisher.processAndPublish(List.of(dto));
     } catch (Exception e) {

--- a/src/main/java/com/stylemycloset/security/jwt/JwtService.java
+++ b/src/main/java/com/stylemycloset/security/jwt/JwtService.java
@@ -1,6 +1,5 @@
 package com.stylemycloset.security.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -47,7 +46,6 @@ public class JwtService {
   private long refreshTokenValiditySeconds;
 
   private final JwtSessionRepository jwtSessionRepository;
-  private final ObjectMapper objectMapper;
   private final JwtBlacklist jwtBlacklist;
   private final UserRepository userRepository;
   private final UserMapper userMapper;
@@ -74,7 +72,7 @@ public class JwtService {
 
     JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
         .subject(userDto.name())
-        .claim("userId", userDto.id())
+        .claim("userId", String.valueOf(userDto.id()))
         .claim("role", userDto.role())
         .claim("definitionName", userDto.name())
         .jwtID(UUID.randomUUID().toString())
@@ -189,7 +187,7 @@ public class JwtService {
       SignedJWT signedJWT = SignedJWT.parse(token);
       JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
 
-      Long userId = claims.getLongClaim("userId");
+      String userId = claims.getStringClaim("userId");
       String role = claims.getStringClaim("role");
       String name = claims.getStringClaim("definitionName");
 
@@ -197,7 +195,7 @@ public class JwtService {
         throw new StyleMyClosetException(ErrorCode.INVALID_TOKEN, Collections.emptyMap());
       }
 
-      return new TokenInfo(userId, role, name);
+      return new TokenInfo(Long.parseLong(userId), role, name);
     } catch (ParseException e) {
       log.error(e.getMessage());
       throw new StyleMyClosetException(ErrorCode.INVALID_TOKEN, Map.of("token", token));

--- a/src/test/java/com/stylemycloset/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/stylemycloset/follow/controller/FollowControllerTest.java
@@ -153,7 +153,7 @@ class FollowControllerTest extends ControllerTestSupport {
   void followers_missingFolloweeId_returns400() {
     // given & when
     MvcTestResult result = mvc.get()
-        .uri("/api/follows/follower?limit=10")
+        .uri("/api/follows/followers?limit=10")
         .exchange();
 
     // then
@@ -165,7 +165,7 @@ class FollowControllerTest extends ControllerTestSupport {
   void followers_limitInvalid_returns400() {
     // given & when
     MvcTestResult result = mvc.get()
-        .uri("/api/follows/follower?followeeId=1&limit=0")
+        .uri("/api/follows/followers?followeeId=1&limit=0")
         .exchange();
 
     // then
@@ -181,7 +181,7 @@ class FollowControllerTest extends ControllerTestSupport {
 
     // when
     MvcTestResult result = mvc.get()
-        .uri("/api/follows/follower?followeeId=1&limit=10&sortDirection=ASC")
+        .uri("/api/follows/followers?followeeId=1&limit=10&sortDirection=ASC")
         .exchange();
 
     // then


### PR DESCRIPTION
## 📋 작업 내용

### 구현 사항

- [ ]  DM 창 오류 문제 해결
- [ ] 팔로워 목록 조회 오류 해결
- [ ] DM 보낼 시  알림 컨텐츠 수정

### 변경 사항 상세

### 1. 무엇을 변경했는지

1.  DM 창 오류 문제 해결
- 프론트의 localeCompare 함수에서 authentication.userId를 String으로 받고 있는데, 서버에선 Long형으로 건네주어 타입 불일치로 DM 창을 띄울 수 없었음. 
=> 프론트에게 전달해주는 userId만 String으로 바꿔 문제 해결

<img width="791" height="406" alt="DM_보냄" src="https://github.com/user-attachments/assets/11d9f3d5-98d4-4ee4-9207-a7f9218c3012" />

2. 팔로워 목록 조회 오류 해결
/api/follows/followers로 받아야 하나 오타로 /follower로 받아 목록을 불러올 수 없었음. 오타 수정으로 해결

<img width="527" height="981" alt="image" src="https://github.com/user-attachments/assets/6372c775-1b05-4fee-8b04-d3de6acdd39d" />

3. DM 보낼 시  알림 컨텐츠 수정
DM 보낼 시 컨텐츠에 DM의 내용을 보이게 수정.

### 2. 왜 변경했는지

<!-- 변경 이유와 배경을 설명해주세요 -->

### 3. 변경으로 인한 효과

<!-- 성능 개선, 사용성 향상 등 변경의 효과를 작성해주세요 -->

## ✅ 테스트 결과

### 테스트 코드 실행 결과

전체 테스트 정상 작동 합니다.

## 🎯 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐야 할 부분을 체크리스트로 작성해주세요 -->


## 🔄 **기능 흐름**


## 📚 관련 위키

<!-- 트러블슈팅 내용이 담긴 위키 링크를 첨부해주세요 -->

- [트러블슈팅: OO 문제 해결](https://www.notion.so/%EC%9C%84%ED%82%A4%EB%A7%81%ED%81%AC1)
- [트러블슈팅: XX 성능 개선](https://www.notion.so/%EC%9C%84%ED%82%A4%EB%A7%81%ED%81%AC2)

## 💭 추가 고려사항

<!-- 향후 개선이 필요한 부분이나 트레이드오프 사항을 작성해주세요 -->


Closes #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 팔로워 목록 조회 API 경로를 /followers로 수정하여 접근 오류와 명명 불일치 해소
- New Features
  - DM 수신 알림에 실제 메시지 내용이 표시되어 알림 가독성 향상
- Refactor
  - 인증 토큰 처리 로직을 정리(기능 변화 없음)
- Tests
  - 변경된 팔로워 경로에 맞춰 테스트 케이스 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->